### PR TITLE
Changed `architecture/poplar-cce-hip` to use non-relocatable device code and link with Cray C++.

### DIFF
--- a/architecture/poplar-cce-hip
+++ b/architecture/poplar-cce-hip
@@ -5,15 +5,15 @@ export USE_OPENMP=1
 export USE_ACCELERATOR = -DACCELERATOR_HIP
 
 export LIBS += 
-export ADD_LIBS += -L$(HDF5DIR) -lhdf5 -L$(MPI_HOME)/lib -lmpi -L$(CRAYLIBS_X86_64) -L$(GCC_X86_64)/lib64 -L$(CRAY_LIBSCI_PREFIX_DIR)/lib -lsci_cray -lcraymath -lcraymp -lu -lcsup -lf -lfi -lmodules -L$(ROCM_PATH)/lib -lhipblas -lrocsolver
+export ADD_LIBS += -L$(HDF5DIR) -lhdf5 -L$(ROCM_PATH)/lib -lhipblas -lrocsolver -lamdhip64
 export INC_PATH += -I$(HDF5INCLUDE) -I$(ROCM_PATH)/include
 
 # export BOOST_ROOT=$(TOP_DIR)
 
 export CXX=CC -g -Ofast -std=c++14 $(USE_ACCELERATOR) -D__HIP_PLATFORM_HCC__
 export F77=ftn $(USE_ACCELERATOR)
-export HIP_CXX=hipcc -fgpu-rdc -g -Ofast -std=c++14 --amdgpu-target=gfx906,gfx908 -Wno-unused-command-line-argument -gcc-toolchain $(GCC_X86_64) $(USE_ACCELERATOR) -I$(MPI_HOME)/include -I$(ROCM_PATH)/include
-export LINKER=$(HIP_CXX)
+export HIP_CXX=hipcc -g -Ofast -std=c++14 --amdgpu-target=gfx906,gfx908 -Wno-unused-command-line-argument -gcc-toolchain $(GCC_X86_64) $(USE_ACCELERATOR) -I$(MPI_HOME)/include -I$(ROCM_PATH)/include
+export LINKER=$(CXX)
 
 ifdef USE_OPENMP
   export CXX += -fopenmp


### PR DESCRIPTION
Previous build used relocatable device code and `hipcc` to link. This did not work with device object files in `ar` libraries. Relocatable device code is not currently necessary for the Hip version, so this change builds with non-relocatable device code and links with the Cray C++ compiler. We still need to find a solution for relocatable device code so it can be used in the future.