### PR TITLE
add IRSXgesv and Xgetrf; some bug fixes; add more NVTX regions

### DIFF
--- a/src/Accelerator/DeviceStorage.hpp
+++ b/src/Accelerator/DeviceStorage.hpp
@@ -62,7 +62,18 @@ private:
   static int *dev_info[MAX_THREADS];
 #if defined(ACCELERATOR_CUDA_C)
   static cublasHandle_t cublas_h[MAX_THREADS];
-  static cusolverDnHandle_t cusolverDnHandle[MAX_THREADS];  
+  static cusolverDnHandle_t cusolverDnHandle[MAX_THREADS];
+#ifdef USE_XGETRF
+  static size_t host_workBytes[MAX_THREADS];  
+  static void *host_work[MAX_THREADS];  
+  static int64_t *dev_ipvt64[MAX_THREADS];  
+  static cusolverDnParams_t cusolverDnParams[MAX_THREADS];
+#endif
+#ifdef USE_IRSXGESV
+  static cusolverDnIRSParams_t cusolverDnIRSParams[MAX_THREADS];
+  static cusolverDnIRSInfos_t cusolverDnIRSInfo[MAX_THREADS];
+  static Complex *dev_X[MAX_THREADS];
+#endif  
   // static cudaEvent_t event[MAX_THREADS];
   // static cudaStream_t stream[MAX_THREADS][2];
 #endif
@@ -100,6 +111,17 @@ public:
   static cudaEvent_t getEvent() { return event[omp_get_thread_num()]; }
   static cublasHandle_t getCublasHandle() { return cublas_h[omp_get_thread_num()]; }
   static cusolverDnHandle_t getCusolverDnHandle() { return cusolverDnHandle[omp_get_thread_num()]; }
+#ifdef USE_XGETRF
+  static int64_t* getDevIpvt64() { return dev_ipvt64[omp_get_thread_num()]; }
+  static size_t getHostWorkBytes() { return host_workBytes[omp_get_thread_num()]; }  
+  static void *getHostWork() {  return host_work[omp_get_thread_num()]; }    
+  static cusolverDnParams_t getCusolverParams() { return cusolverDnParams[omp_get_thread_num()]; }
+#endif
+#ifdef USE_IRSXGESV
+  static cusolverDnIRSParams_t getCusolverIRSParams() { return cusolverDnIRSParams[omp_get_thread_num()]; }
+  static cusolverDnIRSInfos_t getCusolverIRSInfo() { return cusolverDnIRSInfo[omp_get_thread_num()]; }
+  static Complex* getDevX() { return dev_X[omp_get_thread_num()]; }
+#endif
 #endif
 #if defined(ACCELERATOR_HIP)
   static hipblasHandle_t getHipBlasHandle() { return hipblas_h[omp_get_thread_num()]; }

--- a/src/Accelerator/deviceCheckError.hpp
+++ b/src/Accelerator/deviceCheckError.hpp
@@ -23,6 +23,16 @@
    exit(0); \
  }                                                                 \
 }
+
+#define cusolverCheckError(call) {                                    \
+cusolverStatus_t err = call;                                                    \
+if(CUSOLVER_STATUS_SUCCESS != err) {                                                \
+fprintf(stderr, "cuSolver error in file '%s' in line %i : %d.\n",        \
+        __FILE__, __LINE__, err);              \
+fflush(stderr); \
+exit(0);                                                  \
+} }
+
 #endif
 #if defined(ACCELERATOR_HIP)
 #define deviceCheckError() {                                          \

--- a/src/Main/energyContourIntegration.cpp
+++ b/src/Main/energyContourIntegration.cpp
@@ -409,7 +409,7 @@ void energyContourIntegration(LSMSCommunication &comm,LSMSSystemParameters &lsms
       int iie=ie-eGroupIdx[ig];
       Complex energy=egrd[ie];
       Complex pnrel=std::sqrt(energy);
-      if(lsms.global.iprint>=0) printf("Energy #%d (%lf,%lf)\n",ie,real(energy),imag(energy));
+      if(lsms.global.iprint>=-1) printf("Energy #%d (%lf,%lf)\n",ie,real(energy),imag(energy));
       
       double timeCATM=MPI_Wtime();
       calculateAllTauMatrices(comm, lsms, local, vr_con, energy, iie, tau00_l);

--- a/src/MultipleScattering/linearSolvers.hpp
+++ b/src/MultipleScattering/linearSolvers.hpp
@@ -49,6 +49,8 @@ void solveTau00zblocklu_cpp(LSMSSystemParameters &lsms, LocalTypeInfo &local, At
 // #ifdef ACCELERATOR_CUSOLVER
 #define MST_LINEAR_SOLVER_ZZGESV_CUSOLVER 0x12
 #define MST_LINEAR_SOLVER_ZGETRF_CUSOLVER 0x13
+#define MST_LINEAR_SOLVER_XGETRF_CUSOLVER 0x14
+#define MST_LINEAR_SOLVER_IRSXGESV_CUSOLVER 0x15
 // #endif
 
 // #ifdef ACCELERATOR_HIP
@@ -64,7 +66,14 @@ void transferT0MatrixToGPUCuda(Complex *devT0, LSMSSystemParameters &lsms, Local
 void solveTau00zgetrf_cublas(LSMSSystemParameters &lsms, LocalTypeInfo &local, DeviceStorage &d, AtomData &atom, Complex *tMatrix, Complex *devM, Matrix<Complex> &tau00);
 void solveTau00zzgesv_cusolver(LSMSSystemParameters &lsms, LocalTypeInfo &local, DeviceStorage &d, AtomData &atom, Complex *tMatrix, Complex *devM, Matrix<Complex> &tau00);
 void solveTau00zgetrf_cusolver(LSMSSystemParameters &lsms, LocalTypeInfo &local, DeviceStorage &d, AtomData &atom, Complex *tMatrix, Complex *devM, Matrix<Complex> &tau00);
-
+#ifdef USE_XGETRF
+void solveTau00Xgetrf_cusolver(LSMSSystemParameters &lsms, LocalTypeInfo &local, DeviceStorage &d, AtomData &atom,
+                               Complex *tMatrix, Complex *devM, Matrix<Complex> &tau00);
+#endif
+#ifdef USE_IRSXGESV
+void solveTau00IRSXgesv_cusolver(LSMSSystemParameters &lsms, LocalTypeInfo &local, DeviceStorage &d, AtomData &atom,
+                                 Complex *tMatrix, Complex *devM, Matrix<Complex> &tau00);
+#endif
 #define IDX(i, j, lDim) (((j)*(lDim))+(i))
 
 #ifdef __CUDACC__

--- a/src/MultipleScattering/linearSolvers_CUDA.cu
+++ b/src/MultipleScattering/linearSolvers_CUDA.cu
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "Accelerator/DeviceStorage.hpp"
+#include "Accelerator/deviceCheckError.hpp"
 #include <cuda_runtime.h>
 #include <cuComplex.h>
 #include <cublas_v2.h>
@@ -54,6 +55,8 @@ void unitMatrixCuda(T *devM, int lDim, int nCol)
 }
 
 */
+
+
 
 template <typename T>
 __global__ void zeroDiagonalBlocksKernelCuda(T *devM, int lDim, int nCol, int blockSize)
@@ -122,29 +125,33 @@ void solveTau00zgetrf_cublas(LSMSSystemParameters &lsms, LocalTypeInfo &local, D
   cuDoubleComplex *devTau00 = (cuDoubleComplex *)d.getDevTau00();
   // printf("zero Matrix\n");
   zeroMatrixCuda(devTau, nrmat_ns, kkrsz_ns);
+  deviceCheckError();
   // printf("copyTMatrixToTau\n");
   copyTMatrixToTauCuda<<<kkrsz_ns,1>>>(devTau, (cuDoubleComplex *)tMatrix, kkrsz_ns, nrmat_ns);
-
+  deviceCheckError();
+  
   Barray[0] = devTau;
 
   Aarray[0] = (cuDoubleComplex *)devM;
   
   int *ipivArray=d.getDevIpvt();
-  int infoArray[1]; // d.getDevInfo();
+  int *infoArray = d.getDevInfo();
   int info;
 
   // printf("cublasZgetrfBatched\n");
-  cublasZgetrfBatched(cublasHandle, nrmat_ns, Aarray, nrmat_ns, ipivArray, infoArray, 1);
+  cublasCheckError(cublasZgetrfBatched(cublasHandle, nrmat_ns, Aarray, nrmat_ns, ipivArray, infoArray, 1));
   // printf("cublasZgetrsBatched\n");
 
-  cublasZgetrsBatched(cublasHandle, CUBLAS_OP_N, nrmat_ns, kkrsz_ns, Aarray, nrmat_ns, ipivArray,
-                      Barray, nrmat_ns, &info, 1);
+  cublasCheckError(cublasZgetrsBatched(cublasHandle, CUBLAS_OP_N, nrmat_ns, kkrsz_ns, Aarray, nrmat_ns, ipivArray,
+                                 Barray, nrmat_ns, &info, 1));
 
   // copy result into tau00
   // printf("copyTauToTau00\n");
   copyTauToTau00Cuda<<<kkrsz_ns,1>>>(devTau00, devTau, kkrsz_ns, nrmat_ns);
+  deviceCheckError();
   // printf("transferMatrixFromGPU\n");
   transferMatrixFromGPUCuda(tau00, devTau00);
+  deviceCheckError();
 }
 
 #ifndef ARCH_IBM
@@ -197,19 +204,131 @@ void solveTau00zgetrf_cusolver(LSMSSystemParameters &lsms, LocalTypeInfo &local,
   cuDoubleComplex *devWork = (cuDoubleComplex *)d.getDevWork();
 
   int *devIpiv=d.getDevIpvt();
-  int devInfo[1]; // d.getDevInfo();
+  int *devInfo = d.getDevInfo();
 
   zeroMatrixCuda(devTau, nrmat_ns, kkrsz_ns);
+  deviceCheckError();
   copyTMatrixToTauCuda<<<kkrsz_ns,1>>>(devTau, (cuDoubleComplex *)tMatrix, kkrsz_ns, nrmat_ns);
+  deviceCheckError();
+  
+  cusolverCheckError(cusolverDnZgetrf(cusolverDnHandle, nrmat_ns, nrmat_ns, 
+                                      (cuDoubleComplex *)devM, nrmat_ns, devWork, devIpiv,
+                                      devInfo ));
 
-  cusolverDnZgetrf(cusolverDnHandle, nrmat_ns, nrmat_ns, 
-                   (cuDoubleComplex *)devM, nrmat_ns, devWork, devIpiv,
-                   devInfo );
-
-  cusolverDnZgetrs(cusolverDnHandle, CUBLAS_OP_N, nrmat_ns, kkrsz_ns,
-                   (cuDoubleComplex *)devM, nrmat_ns, devIpiv, devTau, nrmat_ns, devInfo);
-
+  cusolverCheckError(cusolverDnZgetrs(cusolverDnHandle, CUBLAS_OP_N, nrmat_ns, kkrsz_ns,
+                                      (cuDoubleComplex *)devM, nrmat_ns, devIpiv, devTau, nrmat_ns, devInfo));
+  
   // copy result into tau00
   copyTauToTau00Cuda<<<kkrsz_ns,1>>>(devTau00, devTau, kkrsz_ns, nrmat_ns);
+  deviceCheckError();
   transferMatrixFromGPUCuda(tau00, devTau00);
+  deviceCheckError();
 }
+
+#ifdef USE_XGETRF
+void solveTau00Xgetrf_cusolver(LSMSSystemParameters &lsms, LocalTypeInfo &local, DeviceStorage &d, AtomData &atom,
+                               Complex *tMatrix, Complex *devM, Matrix<Complex> &tau00)
+{
+  cusolverDnHandle_t cusolverDnHandle = DeviceStorage::getCusolverDnHandle();
+  cusolverDnParams_t cusolverDnParams = DeviceStorage::getCusolverParams();
+  int nrmat_ns = lsms.n_spin_cant*atom.nrmat; // total size of the kkr matrix
+  int kkrsz_ns = lsms.n_spin_cant*atom.kkrsz; // size of t00 block
+  // reference algorithm. Use LU factorization and linear solve for dense matrices in LAPACK
+  cuDoubleComplex *devTau = (cuDoubleComplex *)d.getDevTau();
+  cuDoubleComplex *devTau00 = (cuDoubleComplex *)d.getDevTau00();
+  void *devWork = d.getDevWork();
+  size_t devWorkBytes = d.getDevWorkBytes();
+  int64_t *devIpiv=d.getDevIpvt64();
+  void *hostWork = d.getHostWork();
+  size_t hostWorkBytes = d.getHostWorkBytes();
+  int *devInfo = d.getDevInfo();
+
+  zeroMatrixCuda(devTau, nrmat_ns, kkrsz_ns);
+  deviceCheckError();
+  copyTMatrixToTauCuda<<<kkrsz_ns,1>>>(devTau, (cuDoubleComplex *)tMatrix, kkrsz_ns, nrmat_ns);
+  deviceCheckError();
+
+  cusolverCheckError(cusolverDnXgetrf(cusolverDnHandle,
+                                      cusolverDnParams,
+                                      (int64_t)nrmat_ns,
+                                      (int64_t)nrmat_ns,
+                                      CUDA_C_64F,
+                                      (cuDoubleComplex *)devM,
+                                      (int64_t)nrmat_ns,
+                                      devIpiv,
+                                      CUDA_C_64F,
+                                      devWork,
+                                      devWorkBytes,
+                                      hostWork,
+                                      hostWorkBytes,
+                                      devInfo));
+
+  cusolverCheckError(cusolverDnXgetrs(cusolverDnHandle,
+                                      cusolverDnParams,
+                                      CUBLAS_OP_N,
+                                      (int64_t)nrmat_ns,
+                                      (int64_t)kkrsz_ns,
+                                      CUDA_C_64F,
+                                      (cuDoubleComplex *)devM,
+                                      (int64_t)nrmat_ns,
+                                      devIpiv,
+                                      CUDA_C_64F,
+                                      devTau,
+                                      (int64_t)nrmat_ns,
+                                      devInfo));
+  
+  // copy result into tau00
+  copyTauToTau00Cuda<<<kkrsz_ns,1>>>(devTau00, devTau, kkrsz_ns, nrmat_ns);
+  deviceCheckError();
+  transferMatrixFromGPUCuda(tau00, devTau00);
+  deviceCheckError();
+}
+#endif
+
+#ifdef USE_IRSXGESV
+void solveTau00IRSXgesv_cusolver(LSMSSystemParameters &lsms, LocalTypeInfo &local, DeviceStorage &d, AtomData &atom,
+                                 Complex *tMatrix, Complex *devM, Matrix<Complex> &tau00)
+{
+  cusolverDnHandle_t cusolverDnHandle = DeviceStorage::getCusolverDnHandle();
+  cusolverDnIRSParams_t cusolverDnIRSParams = DeviceStorage::getCusolverIRSParams();
+  cusolverDnIRSInfos_t cusolverDnIRSInfo = DeviceStorage::getCusolverIRSInfo();
+  int nrmat_ns = lsms.n_spin_cant*atom.nrmat; // total size of the kkr matrix
+  int kkrsz_ns = lsms.n_spin_cant*atom.kkrsz; // size of t00 block
+  // reference algorithm. Use LU factorization and linear solve for dense matrices in LAPACK
+  cuDoubleComplex *devTau = (cuDoubleComplex *)d.getDevTau();
+  cuDoubleComplex *devTau00 = (cuDoubleComplex *)d.getDevTau00();
+  cuDoubleComplex *devWork = (cuDoubleComplex *)d.getDevWork();
+  cuDoubleComplex *devX = (cuDoubleComplex *)d.getDevX();
+  size_t devWorkBytes = d.getDevWorkBytes();
+  int *devInfo = d.getDevInfo();
+
+  zeroMatrixCuda(devTau, nrmat_ns, kkrsz_ns);
+  deviceCheckError();
+  copyTMatrixToTauCuda<<<kkrsz_ns,1>>>(devTau, (cuDoubleComplex *)tMatrix, kkrsz_ns, nrmat_ns);
+  deviceCheckError();
+
+  cusolverDnIRSInfos_t info;
+  int niters;
+  cusolverCheckError(cusolverDnIRSXgesv(cusolverDnHandle,
+                                        cusolverDnIRSParams,
+                                        cusolverDnIRSInfo,
+                                        nrmat_ns,
+                                        kkrsz_ns,
+                                        (cuDoubleComplex *)devM,
+                                        nrmat_ns,
+                                        devTau,
+                                        nrmat_ns,
+                                        devX,
+                                        nrmat_ns,
+                                        devWork,
+                                        devWorkBytes,
+                                        &niters,
+                                        devInfo));
+
+  // copy result into tau00
+  copyTauToTau00Cuda<<<kkrsz_ns,1>>>(devTau00, devX, kkrsz_ns, nrmat_ns);
+  deviceCheckError();
+  transferMatrixFromGPUCuda(tau00, devTau00);
+  deviceCheckError();
+}
+#endif


### PR DESCRIPTION
*Add IRSXgesv solver. To enable this:
  Add "-DUSE_IRSXGESV" to USE_ACCELERATOR
  Set ALGORITHM_DEFAULTS = -DMST_LINEAR_SOLVER_DEFAULT=0x015 -DMST_BUILD_KKR_MATRIX_DEFAULT=0x3000
*Add Xgetrf solver. To enable this:
  Add "-DUSE_XGETRF" to USE_ACCELERATOR
  Set export ALGORITHM_DEFAULTS = -DMST_LINEAR_SOLVER_DEFAULT=0x014 -DMST_BUILD_KKR_MATRIX_DEFAULT=0x3000
*Add three new NVTX regions to cover the main computational stage
*Bug fixes:
linearSolvers_CUDA.cu:
  * Use device pointer for "info" array in cuSolver APIs.
DeviceStorage.cu:
  * move cudaFree(dev_bgij) to outside BUILDKKRMATRIX_GPU macro.
  * add code to free cusolverDnHandle
  * remove "*sizeof(cuDoubleComplex)" in dev_workBytes
calculateTauMatrix.cpp:
  * add transferMatrixFromGPUCuda for the old F77 and CPP GPU solvers

Notes:
*CUDA 10.2+ is required for the IRSXgesv solver.
*CUDA 11.1+ is required for the Xgetrf solver
*For those two new solvers, it looks 1 OMP thread is good enough for getting best performance. Since GPU memory usage increases linearly with OMP threads, 1 OMP thread is the recommended way to run LSMS.