### PR TITLE
[build] adds options to the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,8 +190,15 @@ target_link_libraries(lsmscore PUBLIC MPI::MPI_CXX)
 
 
 # Find HDF5
+message(STATUS "Find HDF5")
 set(HDF5_PREFER_PARALLEL false)
 find_package(HDF5 REQUIRED)
+
+message(STATUS "HDF5 C Libaries: " "${HDF5_C_LIBRARIES}")
+message(STATUS "HDF5 LIBRARIES: " "${HDF5_LIBRARIES}")
+message(STATUS "HDF5 INCLUDE DIRS: " "${HDF5_INCLUDE_DIRS}")
+message(STATUS "HDF5 Version: " "${HDF5_VERSION}")
+
 target_link_libraries(lsmscore PUBLIC HDF5::HDF5)
 
 # Linear algebra libraries
@@ -241,6 +248,17 @@ else ()
     endif ()
     target_link_libraries(lsmscore PUBLIC BLAS::BLAS)
 endif ()
+
+# Link Time optimization
+include(CheckIPOSupported)
+check_ipo_supported(RESULT supported OUTPUT error)
+
+if( supported )
+    message(STATUS "IPO / LTO supported")
+else()
+    message(STATUS "IPO / LTO not supported: <${error}>")
+endif()
+
 
 # Lua
 target_link_libraries(lsmscore PUBLIC Lua::Lua)

--- a/cmake/libxc.cmake
+++ b/cmake/libxc.cmake
@@ -67,11 +67,11 @@ if (NOT libxc_FOUND)
     ExternalProject_Add(libxc
             SOURCE_DIR ${_src}
             BUILD_IN_SOURCE true
-            #CONFIGURE_COMMAND find . -type f -print0 | xargs -0 dos2unix
             CONFIGURE_COMMAND ${AUTORECONF_EXECUTABLE} -i
             COMMAND ./configure --prefix=${_install} CC=${CMAKE_C_COMPILER}
             BUILD_COMMAND ${MAKE_EXECUTABLE}
             INSTALL_COMMAND ${MAKE_EXECUTABLE} install
+            BUILD_BYPRODUCTS ${_install}/lib/libxc.a
             )
 
 

--- a/cmake/lua.cmake
+++ b/cmake/lua.cmake
@@ -49,10 +49,17 @@ if (NOT Lua_FOUND)
     ExternalProject_Add(Lua
             SOURCE_DIR ${_src}
             BUILD_IN_SOURCE true
+
 #            CONFIGURE_COMMAND sed -i .tmp -e "/^INSTALL_TOP/c\\\rINSTALL_TOP=${_install}" ${_src}/Makefile
+
             CONFIGURE_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/replace_INSTALL_TOP.cmake ${_src}/Makefile ${_src}/Makefile ${_install}
+
             BUILD_COMMAND ${MAKE_EXECUTABLE} -C ${_src}
+
             INSTALL_COMMAND ${MAKE_EXECUTABLE} install -C ${_src}
+
+            BUILD_BYPRODUCTS ${_install}/lib/liblua.a
+
             )
 endif()
 

--- a/toolchain/summit-gnu-cuda-release.cmake
+++ b/toolchain/summit-gnu-cuda-release.cmake
@@ -1,0 +1,29 @@
+#
+# Toolchain for building LSMS with CUDA on OLCF Summit
+#
+# Currently Loaded Modules:
+#  1) gcc/9.1.0   2) nsight-compute/2021.2.1   3) nsight-systems/2021.3.1.54   
+#  4) cuda/11.0.3   5) essl/6.3.0   6) spectrum-mpi/10.4.0.3-20210112   
+#  7) cmake/3.23.1   8) hdf5/1.12.1
+#
+
+message(STATUS "Use toolchain file")
+
+set(USE_ACCELERATOR_CUDA_C ON)
+set(USE_ESSL ON)
+set(ARCH_IBM ON)
+set(MST_LINEAR_SOLVER_DEFAULT 0x0013)
+set(MST_BUILD_KKR_MATRIX_DEFAULT 0x3000)
+
+set(CMAKE_CXX_COMPILER "mpic++")
+set(CMAKE_C_COMPILER "gcc")
+set(CMAKE_Fortran_COMPILER "gfortran")
+
+set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_CXX_FLAGS "-O3 -mtune=native -mcpu=native")
+set(CMAKE_Fortran_FLAGS "-O3 -mtune=native -mcpu=native")
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+set(CMAKE_OPTIMIZE_DEPENDENCIES TRUE)
+set(CMAKE_Fortran_PREPROCESS TRUE)
+
+


### PR DESCRIPTION
This PR adds various improvements to the cmake build system

- add Ninja support as a build system by specifying the generated libaries as `BUILD_BYPRODUCTS`
- add a release toolchain file for SUMMIT with more optmization turned on
- add options and checks for HDF5 import paths. Last week problems appear with the search path of HDF5 and the default version specified in the module enviroment. The additional output during the generation step should help.
- add option for IPO. CMake also support compiler-aware checks for interprocedural optimization.  