### PR TITLE
fix Madelung monopole calulation for structures with lattice vector of very different length

### DIFF
--- a/.idea/cmake.xml
+++ b/.idea/cmake.xml
@@ -3,6 +3,7 @@
   <component name="CMakeSharedSettings">
     <configurations>
       <configuration PROFILE_NAME="build_release_lsms" ENABLED="true" CONFIG_NAME="Release" TOOLCHAIN_NAME="WSL-gcc-10" GENERATION_OPTIONS="-DBLA_VENDOR=Generic -DCMAKE_CXX_FLAGS=&quot;-O3 -mtune=native&quot; -DCMAKE_Fortran_FLAGS=&quot;-O3 -mtune=native -fbacktrace -cpp -fallow-argument-mismatch&quot; -Dlibxc_LIBRARIES=/home/fmoitzi/Libraries/libxc-5.1.5/lib/libxc.a -Dlibxc_INCLUDE_DIR=/home/fmoitzi/Libraries/libxc-5.1.5/include/" />
+      <configuration PROFILE_NAME="build_debug_lsms" ENABLED="true" TOOLCHAIN_NAME="WSL-gcc-10" GENERATION_OPTIONS="-DBLA_VENDOR=Generic -DCMAKE_Fortran_FLAGS=&quot;-Og -fbacktrace -cpp -fallow-argument-mismatch&quot; -Dlibxc_LIBRARIES=/home/fmoitzi/Libraries/libxc-5.1.5/lib/libxc.a -Dlibxc_INCLUDE_DIR=/home/fmoitzi/Libraries/libxc-5.1.5/include/" />
     </configurations>
   </component>
 </project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="LoopDoesntUseConditionVariable" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedValue" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/Test/Unit/CMakeLists.txt
+++ b/Test/Unit/CMakeLists.txt
@@ -102,3 +102,11 @@ target_link_libraries(test_diff PRIVATE lsmscore)
 
 gtest_discover_tests(test_diff)
 ##################################################################
+
+##################################################################
+add_executable(test_madelung test_madelung.cpp)
+target_link_libraries(test_madelung PUBLIC gtest_main)
+target_link_libraries(test_madelung PRIVATE lsmscore)
+
+gtest_discover_tests(test_madelung)
+##################################################################

--- a/Test/Unit/test_madelung.cpp
+++ b/Test/Unit/test_madelung.cpp
@@ -1,0 +1,170 @@
+//
+// Created by F.Moitzi on 23.06.2022.
+//
+
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <iostream>
+
+#include "Madelung/Madelung.hpp"
+#include "Main/SystemParameters.hpp"
+#include "MultipoleMadelung/calculateMultipoleMadelung.hpp"
+
+template<typename T>
+std::ostream &operator<<(std::ostream &os, const std::vector<T> &v) {
+  os << "[";
+  for (int i = 0; i < v.size(); ++i) {
+    os << v[i];
+    if (i != v.size() - 1)
+      os << ", ";
+  }
+  os << "]";
+  return os;
+}
+
+
+TEST(MadelungsTestSuite, BasicStructure) {
+
+  int num_atoms = 4;
+
+  LSMSSystemParameters lsms;
+  lsms.global.iprint = -1;
+
+  LocalTypeInfo local;
+  local.setNumLocal(4);
+  local.global_id = {0, 1, 2, 3};
+//
+  LocalTypeInfo local_modern = local;
+//
+  CrystalParameters crystal;
+  crystal.resize(num_atoms);
+  crystal.num_atoms = num_atoms;
+  crystal.num_types = num_atoms;
+
+  crystal.bravais(0, 0) = 2.0;
+  crystal.bravais(0, 1) = 0.0;
+  crystal.bravais(0, 2) = 0.0;
+
+  crystal.bravais(1, 0) = 0.1;
+  crystal.bravais(1, 1) = 2.0;
+  crystal.bravais(1, 2) = 0.0;
+
+  crystal.bravais(2, 0) = -0.1;
+  crystal.bravais(2, 1) = 0.05;
+  crystal.bravais(2, 2) = 4.0;
+//
+  crystal.position(0, 0) = 0.0;
+  crystal.position(1, 0) = 0.01;
+  crystal.position(2, 0) = 0.0;
+
+  crystal.position(0, 1) = 0.0;
+  crystal.position(1, 1) = 0.0;
+  crystal.position(2, 1) = 2.0;
+
+  crystal.position(0, 2) = 0.0;
+  crystal.position(1, 2) = 1.0;
+  crystal.position(2, 2) = 0.15;
+
+  crystal.position(0, 3) = 0.0;
+  crystal.position(1, 3) = 1.0;
+  crystal.position(2, 3) = 2.0;
+
+
+  calculateMadelungMatrices(lsms, crystal, local);
+
+  std::cout << std::endl;
+  for (int i = 0; i < num_atoms; i++) {
+    std::cout << local.atom[i].madelungMatrix;
+    std::cout << std::endl;
+  }
+
+  calculateMultiMadelungMatrices(lsms, crystal, local_modern);
+
+  std::cout << std::endl;
+  for (int i = 0; i < num_atoms; i++) {
+    std::cout << local_modern.atom[i].madelungMatrix;
+    std::cout << std::endl;
+  }
+
+  for (int i = 0; i < num_atoms; i++) {
+    for (int j = 0; j < num_atoms; j++) {
+      EXPECT_NEAR (local.atom[i].madelungMatrix[j],
+                   local_modern.atom[i].madelungMatrix[j], 1.0e-12);
+    }
+  }
+
+}
+
+TEST(MadelungsTestSuite, DiffStructure) {
+  int global_num_atoms = 4;
+  int num_atoms = 2;
+
+  LSMSSystemParameters lsms;
+  lsms.global.iprint = -1;
+
+  LocalTypeInfo local;
+  local.setNumLocal(num_atoms);
+  local.global_id = {0, 2};
+//
+  LocalTypeInfo local_modern = local;
+//
+  CrystalParameters crystal;
+  crystal.resize(global_num_atoms);
+  crystal.num_atoms = global_num_atoms;
+  crystal.num_types = global_num_atoms;
+
+  crystal.bravais(0, 0) = 2.0;
+  crystal.bravais(0, 1) = 0.0;
+  crystal.bravais(0, 2) = 0.0;
+
+  crystal.bravais(1, 0) = 0.1;
+  crystal.bravais(1, 1) = 2.0;
+  crystal.bravais(1, 2) = 0.0;
+
+  crystal.bravais(2, 0) = -0.1;
+  crystal.bravais(2, 1) = 0.05;
+  crystal.bravais(2, 2) = 4.0;
+//
+  crystal.position(0, 0) = 0.0;
+  crystal.position(1, 0) = 0.01;
+  crystal.position(2, 0) = 0.0;
+
+  crystal.position(0, 1) = 0.0;
+  crystal.position(1, 1) = 0.0;
+  crystal.position(2, 1) = 2.0;
+
+  crystal.position(0, 2) = 0.0;
+  crystal.position(1, 2) = 1.0;
+  crystal.position(2, 2) = 0.15;
+
+  crystal.position(0, 3) = 0.0;
+  crystal.position(1, 3) = 1.0;
+  crystal.position(2, 3) = 2.0;
+
+
+  calculateMadelungMatrices(lsms, crystal, local);
+
+  std::cout << std::endl;
+  for (int i = 0; i < num_atoms; i++) {
+    std::cout << local.atom[i].madelungMatrix;
+    std::cout << std::endl;
+  }
+
+  calculateMultiMadelungMatrices(lsms, crystal, local_modern);
+
+  std::cout << std::endl;
+  for (int i = 0; i < num_atoms; i++) {
+    std::cout << local_modern.atom[i].madelungMatrix;
+    std::cout << std::endl;
+  }
+
+  for (int i = 0; i < num_atoms; i++) {
+    for (int j = 0; j < global_num_atoms; j++) {
+      EXPECT_NEAR (local.atom[i].madelungMatrix[j],
+                   local_modern.atom[i].madelungMatrix[j], 1.0e-12);
+    }
+  }
+
+}
+

--- a/include/Array3d.hpp
+++ b/include/Array3d.hpp
@@ -116,6 +116,10 @@
       return data[k*lDim12+j*lDim1+i];
     }
 
+    inline T operator() (size_type i, size_type j, size_type k) const {
+      return data[k*lDim12+j*lDim1+i];
+    }
+
   // The second way to access the elements of a matrix uses the familair C |[]| operator and vies the |data| array as a continous block of memory.
     inline T& operator[](size_type i) {
       return data[i];

--- a/include/Array3d.hpp
+++ b/include/Array3d.hpp
@@ -116,6 +116,7 @@
       return data[k*lDim12+j*lDim1+i];
     }
 
+   // Enable also const access
     inline T operator() (size_type i, size_type j, size_type k) const {
       return data[k*lDim12+j*lDim1+i];
     }

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -15,4 +15,5 @@ target_sources(
          Matrix.hpp
          PhysicalConstants.hpp
          Real.hpp
+         NDArray.hpp
          TypeTraits.hpp)

--- a/include/Matrix.hpp
+++ b/include/Matrix.hpp
@@ -131,13 +131,7 @@
       return data[j*lDim+i];
     }
 
-    // <Matrix Access@>;
-    // We provide two methods to access the lements of a matrix. The most natural one uses |operator()| with row and collumn arguments and looks simimar to a matrix access in {\bf Fortran}.
-    inline const T& operator() (size_type i, size_type j) const {
-      // ASSERT(i<nRow,
-      //        std::range_error("i>=n_row in T& Matrix<T>::operator()(size_type i,size_type j"));
-      // ASSERT(j<nCol,
-      //        std::range_error("j>=n_col in T& Matrix<T>::operator()(size_type i,size_type j"));
+    inline T operator() (size_type i, size_type j) const {
       return data[j*lDim+i];
     }
 

--- a/include/Matrix.hpp
+++ b/include/Matrix.hpp
@@ -131,6 +131,7 @@
       return data[j*lDim+i];
     }
 
+    // Const access to elements
     inline T operator() (size_type i, size_type j) const {
       return data[j*lDim+i];
     }

--- a/include/NDArray.hpp
+++ b/include/NDArray.hpp
@@ -1,0 +1,348 @@
+///
+/// Created by F.Moitzi on 09.01.2022.
+///
+/// The memory layout of this class is designed to be the same in {\bf Fortran}.
+///
+
+#ifndef MULTIARRAY_HPP
+#define MULTIARRAY_HPP
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+#include <memory>
+#include <type_traits>
+#include <algorithm>
+#include <numeric>
+#include <array>
+
+namespace detail {
+  template<bool...>
+  struct bool_pack;
+  template<bool... bs>
+  using all_true = std::is_same<bool_pack<bs..., true>, bool_pack<true, bs...>>;
+}
+
+template<typename... Ts>
+using all_true = detail::all_true<Ts::value...>;
+
+template<typename T, typename... Ts>
+using all_same = all_true<std::is_same<T, Ts>...>;
+
+
+namespace lsms {
+
+
+  template<typename std::size_t Size>
+  using array_t = std::array<std::size_t, Size>;
+
+  template<typename T>
+  using allocator_t = std::allocator<T>;
+
+  using size_t = std::size_t;
+
+  template<class T>
+  class ArrayItem {
+
+    using iterator = typename std::vector<ArrayItem<T>>::iterator;
+    using const_iterator = typename std::vector<ArrayItem<T>>::const_iterator;
+
+  private:
+
+    bool is_array_;
+    std::vector<ArrayItem<T>> v_;
+    T val_;
+
+  public:
+
+
+    explicit ArrayItem(const std::vector<ArrayItem<T>> &a)
+        : is_array_{true}, v_(a), val_{0} {
+    }
+
+    ArrayItem(std::initializer_list<ArrayItem<T>> list)
+        : is_array_{true}, v_(list), val_{0} {
+    }
+
+    ArrayItem(T val) // Cannot be explicit
+        : is_array_{false}, val_{val} {
+    }
+
+    ArrayItem() : is_array_{false} {};
+
+    ArrayItem(const ArrayItem &) = default;
+
+    ArrayItem(ArrayItem &&) noexcept = default;
+
+    bool is_array() const { return is_array_; }
+
+    size_t size() const { return v_.size(); }
+
+    T value() const { return val_; }
+
+    iterator begin() { return v_.begin(); }
+
+    iterator end() { return v_.end(); }
+
+    const_iterator begin() const { return v_.begin(); };
+
+    const_iterator end() const { return v_.end(); };
+
+
+  };
+
+
+  class ColumnMajor {
+
+  public:
+
+    template<size_t N>
+    static void calculate_strides(const array_t<N> &shape, array_t<N> &strides) {
+      size_t size = 1;
+      for (size_t i = 0; i < N; ++i) {
+        strides[i] = size;
+        size *= shape[i];
+      }
+    }
+
+  };
+
+  template<typename Pointer>
+  inline typename std::pointer_traits<Pointer>::element_type *to_plain_pointer(Pointer ptr) {
+    return (std::addressof(*ptr));
+  }
+
+
+  template<size_t N, typename... Indices>
+  inline size_t get_offset(array_t<N> strides, Indices... indices) {
+
+    const array_t<N> inds{indices...};
+
+    size_t off{0};
+    for (auto i = 0; i < N; i++) {
+      off += strides[i] * inds[i];
+    }
+
+    return off;
+  }
+
+
+  template<typename T, size_t N>
+  class NDArray {
+
+  private:
+
+    T *data_ = nullptr; // null pointer literal
+
+    size_t size_{0}; // total number of elements
+
+    array_t<N> shape_; // shape of the n-dims array (can be change)
+
+    array_t<N> strides_; //
+
+    allocator_t<T> allocator_; // allocator
+
+    void dim_from_initializer_list(const ArrayItem<T> &init, size_t shape) {
+      bool is_array = false;
+      size_t size = 0;
+
+      size_t i = 0;
+      for (const auto &item : init) {
+
+        if (i == 0) {
+          is_array = item.is_array();
+          size = item.size();
+          if (shape < N) {
+            shape_[shape++] = init.size();
+            if (is_array) {
+              dim_from_initializer_list(item, shape);
+            }
+          }
+        } else {
+
+          if (is_array) {
+
+            if (!item.is_array() || item.size() != size) {
+
+              throw std::invalid_argument("initializer list contains non-conforming shapes");
+
+            }
+
+          } else if (shape != N) {
+
+            throw std::invalid_argument("initializer list incompatible with array dimensionality");
+
+          }
+        }
+
+        ++i;
+      }
+    }
+
+
+    void data_from_initializer_list(const ArrayItem<T> &init, array_t<N> &indices, size_t index) {
+      size_t i = 0;
+      for (const auto &item : init) {
+        indices[index] = i;
+
+        if (item.is_array()) {
+
+          data_from_initializer_list(item, indices, index + 1);
+
+        } else {
+
+          size_t offset = get_offset<N>(strides_, indices);
+          if (offset < size()) {
+            data_[offset] = item.value();
+          }
+
+        }
+
+        ++i;
+      }
+    }
+
+
+  public:
+
+
+    NDArray() {
+      std::fill(std::begin(shape_), std::end(shape_), 0);
+      std::fill(std::begin(strides_), std::end(strides_), 0);
+    };
+
+    template<typename... Args>
+    explicit NDArray(size_t i, Args... args) : shape_{i, args...} {
+      static_assert(sizeof...(args) != N, "Number of arguments are wrong!");
+      size_ = std::accumulate(std::begin(shape_), std::end(shape_), 1, std::multiplies<decltype(N)>());
+      ColumnMajor::calculate_strides<N>(shape_, strides_);
+      data_ = allocator_.allocate(size_);
+      T def{};
+      std::fill_n(data_, size_, def);
+    };
+
+    ~NDArray() {
+      allocator_.deallocate(data_, size_);
+    }
+
+    NDArray(const NDArray &other)
+        : data_(nullptr),
+          size_(other.size()),
+          shape_{other.shape_},
+          strides_{other.strides_} {
+      data_ = allocator_.allocate(size_);
+      std::copy(other.data_, other.data_ + other.size_, data_);
+    }
+
+    NDArray(NDArray &&other) noexcept
+        : data_(std::exchange(other.data_, nullptr)),
+          size_(std::move(other.size())),
+          shape_(std::move(other.shape_)),
+          strides_(std::move(other.strides_)) {
+    };
+
+    friend void assign(NDArray &lhs, const NDArray &rhs) {
+      lhs.size_ = rhs.size_;
+      lhs.shape_ = rhs.shape_;
+      lhs.strides_ = rhs.strides_;
+    }
+
+    NDArray &operator=(const NDArray &other) {
+
+      if (this != &other) {
+        assign(*this, other);
+        data_ = allocator_.allocate(other.size_);
+        std::copy(other.data_, other.data_ + other.size_, data_);
+      }
+      return *this;
+    }
+
+
+    NDArray &operator=(NDArray &&other) noexcept {
+      if (data_) allocator_.deallocate(data_, size_);
+      data_ = std::exchange(other.data_, nullptr);
+      size_ = std::move(other.size());
+      shape_ = std::move(other.shape_);
+      strides_ = std::move(other.strides_);
+      return *this;
+    };
+
+
+    // get access operator
+    template<typename... Indices>
+    inline T &operator()(size_t i, Indices... indices) {
+      static_assert(sizeof...(indices) != N, "Number of arguments are wrong!");
+      return data_[get_offset<N>(strides_, i, indices...)];
+    }
+
+    template<typename... Indices>
+    inline const T &operator()(size_t i, Indices... indices) const {
+      static_assert(sizeof...(indices) != N, "Number of arguments are wrong!");
+      return data_[get_offset<N>(strides_, i, indices...)];
+    }
+
+    inline NDArray &operator=(const T &val) {
+      std::fill(data_, data_ + size_, val);
+      return *this;
+    }
+
+    void scale(const T &val) {
+      std::transform(data_, data_ + size_, data_, [val](T &c) { return c * val; });
+    }
+
+    inline NDArray &operator*=(const T &val) {
+      std::transform(data_, data_ + size_, data_, [val](T &c) { return c * val; });
+      return *this;
+    }
+
+    inline NDArray &operator/=(const T &val) {
+      std::transform(data_, data_ + size_, data_, [val](T &c) { return c / val; });
+      return *this;
+    }
+
+
+    template<typename Indices>
+    inline T &operator[](Indices i) {
+      return data_[i];
+    }
+
+    std::size_t size() const {
+      return size_;
+    }
+
+    const array_t<N> &shape() const { return shape_; }
+
+    const array_t<N> &strides() const { return strides_; }
+
+    T *data() {
+      return to_plain_pointer(data_);
+    }
+
+    const T *data() const {
+      return to_plain_pointer(data_);
+    }
+
+    size_t shape(size_t i) const { return shape_[i]; }
+
+
+    NDArray(std::initializer_list<ArrayItem<T>> list) {
+
+      dim_from_initializer_list(list, 0);
+
+      ColumnMajor::calculate_strides<N>(shape_, strides_);
+
+      size_ = std::accumulate(std::begin(shape_), std::end(shape_), 1, std::multiplies<decltype(N)>());
+
+      data_ = allocator_.allocate(size_);
+
+      data_from_initializer_list(list, shape_, 0);
+
+    }
+
+
+  };
+
+
+}
+
+#endif //MULTIARRAY_HPP

--- a/include/NDArray.hpp
+++ b/include/NDArray.hpp
@@ -7,342 +7,298 @@
 #ifndef MULTIARRAY_HPP
 #define MULTIARRAY_HPP
 
-#include <cstddef>
-#include <stdexcept>
-#include <vector>
-#include <memory>
-#include <type_traits>
 #include <algorithm>
-#include <numeric>
 #include <array>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
 
 namespace detail {
-  template<bool...>
-  struct bool_pack;
-  template<bool... bs>
-  using all_true = std::is_same<bool_pack<bs..., true>, bool_pack<true, bs...>>;
-}
+template <bool...>
+struct bool_pack;
+template <bool... bs>
+using all_true = std::is_same<bool_pack<bs..., true>, bool_pack<true, bs...>>;
+}  // namespace detail
 
-template<typename... Ts>
+template <typename... Ts>
 using all_true = detail::all_true<Ts::value...>;
 
-template<typename T, typename... Ts>
+template <typename T, typename... Ts>
 using all_same = all_true<std::is_same<T, Ts>...>;
-
 
 namespace lsms {
 
+template <typename std::size_t Size>
+using array_t = std::array<std::size_t, Size>;
 
-  template<typename std::size_t Size>
-  using array_t = std::array<std::size_t, Size>;
+template <typename T>
+using allocator_t = std::allocator<T>;
 
-  template<typename T>
-  using allocator_t = std::allocator<T>;
+using size_t = std::size_t;
 
-  using size_t = std::size_t;
+template <class T>
+class ArrayItem {
+  using iterator = typename std::vector<ArrayItem<T>>::iterator;
+  using const_iterator = typename std::vector<ArrayItem<T>>::const_iterator;
 
-  template<class T>
-  class ArrayItem {
+ private:
+  bool is_array_;
+  std::vector<ArrayItem<T>> v_;
+  T val_;
 
-    using iterator = typename std::vector<ArrayItem<T>>::iterator;
-    using const_iterator = typename std::vector<ArrayItem<T>>::const_iterator;
+ public:
+  explicit ArrayItem(const std::vector<ArrayItem<T>> &a)
+      : is_array_{true}, v_(a), val_{0} {}
 
-  private:
+  ArrayItem(std::initializer_list<ArrayItem<T>> list)
+      : is_array_{true}, v_(list), val_{0} {}
 
-    bool is_array_;
-    std::vector<ArrayItem<T>> v_;
-    T val_;
+  ArrayItem(T val)  // Cannot be explicit
+      : is_array_{false}, val_{val} {}
 
-  public:
+  ArrayItem() : is_array_{false} {};
 
+  ArrayItem(const ArrayItem &) = default;
 
-    explicit ArrayItem(const std::vector<ArrayItem<T>> &a)
-        : is_array_{true}, v_(a), val_{0} {
+  ArrayItem(ArrayItem &&) noexcept = default;
+
+  bool is_array() const { return is_array_; }
+
+  size_t size() const { return v_.size(); }
+
+  T value() const { return val_; }
+
+  iterator begin() { return v_.begin(); }
+
+  iterator end() { return v_.end(); }
+
+  const_iterator begin() const { return v_.begin(); };
+
+  const_iterator end() const { return v_.end(); };
+};
+
+class ColumnMajor {
+ public:
+  template <size_t N>
+  static void calculate_strides(const array_t<N> &shape, array_t<N> &strides) {
+    size_t size = 1;
+    for (size_t i = 0; i < N; ++i) {
+      strides[i] = size;
+      size *= shape[i];
     }
-
-    ArrayItem(std::initializer_list<ArrayItem<T>> list)
-        : is_array_{true}, v_(list), val_{0} {
-    }
-
-    ArrayItem(T val) // Cannot be explicit
-        : is_array_{false}, val_{val} {
-    }
-
-    ArrayItem() : is_array_{false} {};
-
-    ArrayItem(const ArrayItem &) = default;
-
-    ArrayItem(ArrayItem &&) noexcept = default;
-
-    bool is_array() const { return is_array_; }
-
-    size_t size() const { return v_.size(); }
-
-    T value() const { return val_; }
-
-    iterator begin() { return v_.begin(); }
-
-    iterator end() { return v_.end(); }
-
-    const_iterator begin() const { return v_.begin(); };
-
-    const_iterator end() const { return v_.end(); };
-
-
-  };
-
-
-  class ColumnMajor {
-
-  public:
-
-    template<size_t N>
-    static void calculate_strides(const array_t<N> &shape, array_t<N> &strides) {
-      size_t size = 1;
-      for (size_t i = 0; i < N; ++i) {
-        strides[i] = size;
-        size *= shape[i];
-      }
-    }
-
-  };
-
-  template<typename Pointer>
-  inline typename std::pointer_traits<Pointer>::element_type *to_plain_pointer(Pointer ptr) {
-    return (std::addressof(*ptr));
   }
-
-
-  template<size_t N, typename... Indices>
-  inline size_t get_offset(array_t<N> strides, Indices... indices) {
-
-    const array_t<N> inds{indices...};
-
-    size_t off{0};
-    for (auto i = 0; i < N; i++) {
-      off += strides[i] * inds[i];
-    }
-
-    return off;
-  }
-
-
-  template<typename T, size_t N>
-  class NDArray {
-
-  private:
-
-    T *data_ = nullptr; // null pointer literal
-
-    size_t size_{0}; // total number of elements
-
-    array_t<N> shape_; // shape of the n-dims array (can be change)
-
-    array_t<N> strides_; //
-
-    allocator_t<T> allocator_; // allocator
-
-    void dim_from_initializer_list(const ArrayItem<T> &init, size_t shape) {
-      bool is_array = false;
-      size_t size = 0;
-
-      size_t i = 0;
-      for (const auto &item : init) {
-
-        if (i == 0) {
-          is_array = item.is_array();
-          size = item.size();
-          if (shape < N) {
-            shape_[shape++] = init.size();
-            if (is_array) {
-              dim_from_initializer_list(item, shape);
-            }
-          }
-        } else {
-
-          if (is_array) {
-
-            if (!item.is_array() || item.size() != size) {
-
-              throw std::invalid_argument("initializer list contains non-conforming shapes");
-
-            }
-
-          } else if (shape != N) {
-
-            throw std::invalid_argument("initializer list incompatible with array dimensionality");
-
-          }
-        }
-
-        ++i;
-      }
-    }
-
-
-    void data_from_initializer_list(const ArrayItem<T> &init, array_t<N> &indices, size_t index) {
-      size_t i = 0;
-      for (const auto &item : init) {
-        indices[index] = i;
-
-        if (item.is_array()) {
-
-          data_from_initializer_list(item, indices, index + 1);
-
-        } else {
-
-          size_t offset = get_offset<N>(strides_, indices);
-          if (offset < size()) {
-            data_[offset] = item.value();
-          }
-
-        }
-
-        ++i;
-      }
-    }
-
-
-  public:
-
-
-    NDArray() {
-      std::fill(std::begin(shape_), std::end(shape_), 0);
-      std::fill(std::begin(strides_), std::end(strides_), 0);
-    };
-
-    template<typename... Args>
-    explicit NDArray(size_t i, Args... args) : shape_{i, args...} {
-      static_assert(sizeof...(args) != N, "Number of arguments are wrong!");
-      size_ = std::accumulate(std::begin(shape_), std::end(shape_), 1, std::multiplies<decltype(N)>());
-      ColumnMajor::calculate_strides<N>(shape_, strides_);
-      data_ = allocator_.allocate(size_);
-      T def{};
-      std::fill_n(data_, size_, def);
-    };
-
-    ~NDArray() {
-      allocator_.deallocate(data_, size_);
-    }
-
-    NDArray(const NDArray &other)
-        : data_(nullptr),
-          size_(other.size()),
-          shape_{other.shape_},
-          strides_{other.strides_} {
-      data_ = allocator_.allocate(size_);
-      std::copy(other.data_, other.data_ + other.size_, data_);
-    }
-
-    NDArray(NDArray &&other) noexcept
-        : data_(std::exchange(other.data_, nullptr)),
-          size_(std::move(other.size())),
-          shape_(std::move(other.shape_)),
-          strides_(std::move(other.strides_)) {
-    };
-
-    friend void assign(NDArray &lhs, const NDArray &rhs) {
-      lhs.size_ = rhs.size_;
-      lhs.shape_ = rhs.shape_;
-      lhs.strides_ = rhs.strides_;
-    }
-
-    NDArray &operator=(const NDArray &other) {
-
-      if (this != &other) {
-        assign(*this, other);
-        data_ = allocator_.allocate(other.size_);
-        std::copy(other.data_, other.data_ + other.size_, data_);
-      }
-      return *this;
-    }
-
-
-    NDArray &operator=(NDArray &&other) noexcept {
-      if (data_) allocator_.deallocate(data_, size_);
-      data_ = std::exchange(other.data_, nullptr);
-      size_ = std::move(other.size());
-      shape_ = std::move(other.shape_);
-      strides_ = std::move(other.strides_);
-      return *this;
-    };
-
-
-    // get access operator
-    template<typename... Indices>
-    inline T &operator()(size_t i, Indices... indices) {
-      static_assert(sizeof...(indices) != N, "Number of arguments are wrong!");
-      return data_[get_offset<N>(strides_, i, indices...)];
-    }
-
-    template<typename... Indices>
-    inline const T &operator()(size_t i, Indices... indices) const {
-      static_assert(sizeof...(indices) != N, "Number of arguments are wrong!");
-      return data_[get_offset<N>(strides_, i, indices...)];
-    }
-
-    inline NDArray &operator=(const T &val) {
-      std::fill(data_, data_ + size_, val);
-      return *this;
-    }
-
-    void scale(const T &val) {
-      std::transform(data_, data_ + size_, data_, [val](T &c) { return c * val; });
-    }
-
-    inline NDArray &operator*=(const T &val) {
-      std::transform(data_, data_ + size_, data_, [val](T &c) { return c * val; });
-      return *this;
-    }
-
-    inline NDArray &operator/=(const T &val) {
-      std::transform(data_, data_ + size_, data_, [val](T &c) { return c / val; });
-      return *this;
-    }
-
-
-    template<typename Indices>
-    inline T &operator[](Indices i) {
-      return data_[i];
-    }
-
-    std::size_t size() const {
-      return size_;
-    }
-
-    const array_t<N> &shape() const { return shape_; }
-
-    const array_t<N> &strides() const { return strides_; }
-
-    T *data() {
-      return to_plain_pointer(data_);
-    }
-
-    const T *data() const {
-      return to_plain_pointer(data_);
-    }
-
-    size_t shape(size_t i) const { return shape_[i]; }
-
-
-    NDArray(std::initializer_list<ArrayItem<T>> list) {
-
-      dim_from_initializer_list(list, 0);
-
-      ColumnMajor::calculate_strides<N>(shape_, strides_);
-
-      size_ = std::accumulate(std::begin(shape_), std::end(shape_), 1, std::multiplies<decltype(N)>());
-
-      data_ = allocator_.allocate(size_);
-
-      data_from_initializer_list(list, shape_, 0);
-
-    }
-
-
-  };
-
-
+};
+
+template <typename Pointer>
+inline typename std::pointer_traits<Pointer>::element_type *to_plain_pointer(
+    Pointer ptr) {
+  return (std::addressof(*ptr));
 }
 
-#endif //MULTIARRAY_HPP
+template <size_t N, typename... Indices>
+inline size_t get_offset(array_t<N> strides, Indices... indices) {
+  const array_t<N> inds{indices...};
+
+  size_t off{0};
+  for (auto i = 0; i < N; i++) {
+    off += strides[i] * inds[i];
+  }
+
+  return off;
+}
+
+template <typename T, size_t N>
+class NDArray {
+ private:
+  T *data_ = nullptr;  // null pointer literal
+
+  size_t size_{0};  // total number of elements
+
+  array_t<N> shape_;  // shape of the n-dims array (can be change)
+
+  array_t<N> strides_;  //
+
+  allocator_t<T> allocator_;  // allocator
+
+  void dim_from_initializer_list(const ArrayItem<T> &init, size_t shape) {
+    bool is_array = false;
+    size_t size = 0;
+
+    size_t i = 0;
+    for (const auto &item : init) {
+      if (i == 0) {
+        is_array = item.is_array();
+        size = item.size();
+        if (shape < N) {
+          shape_[shape++] = init.size();
+          if (is_array) {
+            dim_from_initializer_list(item, shape);
+          }
+        }
+      } else {
+        if (is_array) {
+          if (!item.is_array() || item.size() != size) {
+            throw std::invalid_argument(
+                "initializer list contains non-conforming shapes");
+          }
+
+        } else if (shape != N) {
+          throw std::invalid_argument(
+              "initializer list incompatible with array dimensionality");
+        }
+      }
+
+      ++i;
+    }
+  }
+
+  void data_from_initializer_list(const ArrayItem<T> &init, array_t<N> &indices,
+                                  size_t index) {
+    size_t i = 0;
+    for (const auto &item : init) {
+      indices[index] = i;
+
+      if (item.is_array()) {
+        data_from_initializer_list(item, indices, index + 1);
+
+      } else {
+        size_t offset = get_offset<N>(strides_, indices);
+        if (offset < size()) {
+          data_[offset] = item.value();
+        }
+      }
+
+      ++i;
+    }
+  }
+
+ public:
+  NDArray() {
+    std::fill(std::begin(shape_), std::end(shape_), 0);
+    std::fill(std::begin(strides_), std::end(strides_), 0);
+  };
+
+  template <typename... Args>
+  explicit NDArray(size_t i, Args... args) : shape_{i, args...} {
+    static_assert(sizeof...(args) != N, "Number of arguments are wrong!");
+    size_ = std::accumulate(std::begin(shape_), std::end(shape_), 1,
+                            std::multiplies<decltype(N)>());
+    ColumnMajor::calculate_strides<N>(shape_, strides_);
+    data_ = allocator_.allocate(size_);
+    T def{};
+    std::fill_n(data_, size_, def);
+  };
+
+  ~NDArray() { allocator_.deallocate(data_, size_); }
+
+  NDArray(const NDArray &other)
+      : data_(nullptr),
+        size_(other.size()),
+        shape_{other.shape_},
+        strides_{other.strides_} {
+    data_ = allocator_.allocate(size_);
+    std::copy(other.data_, other.data_ + other.size_, data_);
+  }
+
+  NDArray(NDArray &&other) noexcept
+      : data_(std::exchange(other.data_, nullptr)),
+        size_(std::move(other.size())),
+        shape_(std::move(other.shape_)),
+        strides_(std::move(other.strides_)){};
+
+  friend void assign(NDArray &lhs, const NDArray &rhs) {
+    lhs.size_ = rhs.size_;
+    lhs.shape_ = rhs.shape_;
+    lhs.strides_ = rhs.strides_;
+  }
+
+  NDArray &operator=(const NDArray &other) {
+    if (this != &other) {
+      assign(*this, other);
+      data_ = allocator_.allocate(other.size_);
+      std::copy(other.data_, other.data_ + other.size_, data_);
+    }
+    return *this;
+  }
+
+  NDArray &operator=(NDArray &&other) noexcept {
+    if (data_) allocator_.deallocate(data_, size_);
+    data_ = std::exchange(other.data_, nullptr);
+    size_ = std::move(other.size());
+    shape_ = std::move(other.shape_);
+    strides_ = std::move(other.strides_);
+    return *this;
+  };
+
+  // get access operator
+  template <typename... Indices>
+  inline T &operator()(size_t i, Indices... indices) {
+    static_assert(sizeof...(indices) != N, "Number of arguments are wrong!");
+    return data_[get_offset<N>(strides_, i, indices...)];
+  }
+
+  template <typename... Indices>
+  inline const T &operator()(size_t i, Indices... indices) const {
+    static_assert(sizeof...(indices) != N, "Number of arguments are wrong!");
+    return data_[get_offset<N>(strides_, i, indices...)];
+  }
+
+  inline NDArray &operator=(const T &val) {
+    std::fill(data_, data_ + size_, val);
+    return *this;
+  }
+
+  void scale(const T &val) {
+    std::transform(data_, data_ + size_, data_,
+                   [val](T &c) { return c * val; });
+  }
+
+  inline NDArray &operator*=(const T &val) {
+    std::transform(data_, data_ + size_, data_,
+                   [val](T &c) { return c * val; });
+    return *this;
+  }
+
+  inline NDArray &operator/=(const T &val) {
+    std::transform(data_, data_ + size_, data_,
+                   [val](T &c) { return c / val; });
+    return *this;
+  }
+
+  template <typename Indices>
+  inline T &operator[](Indices i) {
+    return data_[i];
+  }
+
+  std::size_t size() const { return size_; }
+
+  const array_t<N> &shape() const { return shape_; }
+
+  const array_t<N> &strides() const { return strides_; }
+
+  T *data() { return to_plain_pointer(data_); }
+
+  const T *data() const { return to_plain_pointer(data_); }
+
+  size_t shape(size_t i) const { return shape_[i]; }
+
+  NDArray(std::initializer_list<ArrayItem<T>> list) {
+    dim_from_initializer_list(list, 0);
+
+    ColumnMajor::calculate_strides<N>(shape_, strides_);
+
+    size_ = std::accumulate(std::begin(shape_), std::end(shape_), 1,
+                            std::multiplies<decltype(N)>());
+
+    data_ = allocator_.allocate(size_);
+
+    data_from_initializer_list(list, shape_, 0);
+  }
+};
+
+}  // namespace lsms
+
+#endif  // MULTIARRAY_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,5 @@
 
 #
-# External libaries
-#
-
-FetchContent_Declare(
-        span-lite
-        GIT_REPOSITORY https://github.com/martinmoene/span-lite.git
-)
-FetchContent_MakeAvailable(span-lite)
-
-#
 #
 #
 add_executable(lsms_main)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,15 @@
 
 #
+# External libaries
+#
+
+FetchContent_Declare(
+        span-lite
+        GIT_REPOSITORY https://github.com/martinmoene/span-lite.git
+)
+FetchContent_MakeAvailable(span-lite)
+
+#
 #
 #
 add_executable(lsms_main)
@@ -10,7 +20,15 @@ set_target_properties(lsms_main
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
         )
 
+option(LEGACY_MONOPOLE "Use legacy for mono poles" OFF)
+
+if(LEGACY_MONOPOLE)
+    target_compile_definitions(lsms_main PUBLIC LEGACY_MONOPOLE)
+endif()
+
 add_library(lsmscore)
+
+target_link_libraries(lsmscore PUBLIC span-lite)
 
 target_link_libraries(lsms_main
         PUBLIC lsmscore)
@@ -57,6 +75,8 @@ add_subdirectory(LuaInterface)
 add_subdirectory(Main)
 
 add_subdirectory(Madelung)
+
+add_subdirectory(MultipoleMadelung)
 
 add_subdirectory(Misc)
 

--- a/src/Madelung/Madelung.cpp
+++ b/src/Madelung/Madelung.cpp
@@ -16,7 +16,6 @@ void calculateMadelungMatrices(LSMSSystemParameters &lsms, CrystalParameters &cr
     atom_position_3[i]=crystal.position(2,i);
   }
 
-
   // int lmax=1;
   // int ndlmadv=((lmax+1)*(lmax+2))/2;
   int num_atoms=crystal.num_atoms;

--- a/src/Madelung/Madelung.cpp
+++ b/src/Madelung/Madelung.cpp
@@ -16,6 +16,7 @@ void calculateMadelungMatrices(LSMSSystemParameters &lsms, CrystalParameters &cr
     atom_position_3[i]=crystal.position(2,i);
   }
 
+
   // int lmax=1;
   // int ndlmadv=((lmax+1)*(lmax+2))/2;
   int num_atoms=crystal.num_atoms;

--- a/src/Main/lsms.cpp
+++ b/src/Main/lsms.cpp
@@ -33,6 +33,7 @@
 #include "Misc/Indices.hpp"
 #include "Misc/Coeficients.hpp"
 #include "Madelung/Madelung.hpp"
+#include "MultipoleMadelung/calculateMultipoleMadelung.hpp"
 #include "VORPOL/VORPOL.hpp"
 #include "energyContourIntegration.hpp"
 #include "Accelerator/Accelerator.hpp"
@@ -390,7 +391,11 @@ int main(int argc, char *argv[])
   setupMixing(mix, mixing, lsms.global.iprint);
 
 // need to calculate madelung matrices
+#ifdef LEGACY_MONOPOLE
   calculateMadelungMatrices(lsms, crystal, local);
+#else
+  calculateMultiMadelungMatrices(lsms, crystal, local);
+#endif
 
   if (lsms.global.iprint >= 1)
   {

--- a/src/MultipoleMadelung/CMakeLists.txt
+++ b/src/MultipoleMadelung/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+
+target_sources(lsmscore PUBLIC
+        calculateMultipoleMadelung.hpp
+        calculateMultipoleMadelung.cpp
+        MultipoleMadelung.cpp
+        MultipoleMadelung.hpp
+        lattice_utils.cpp
+        lattice_utils.hpp
+        monopole_madelung.cpp
+        monopole_madelung.hpp
+        madelung_term.hpp
+        integer_factors.hpp
+        integer_factors.cpp
+        utils.hpp
+        debug.hpp
+        common.hpp)
+
+target_include_directories(lsmscore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/MultipoleMadelung/MultipoleMadelung.cpp
+++ b/src/MultipoleMadelung/MultipoleMadelung.cpp
@@ -1,0 +1,119 @@
+//
+// Created by F.Moitzi on 16.12.2021.
+//
+
+#include "MultipoleMadelung.hpp"
+
+#include <complex>
+#include <vector>
+
+#include "lattice_utils.hpp"
+#include "madelung_term.hpp"
+#include "monopole_madelung.hpp"
+
+lsms::MultipoleMadelung::MultipoleMadelung(LSMSSystemParameters &lsms,
+                                           CrystalParameters &crystal,
+                                           LocalTypeInfo &local)
+    : num_atoms{crystal.num_atoms}, lmax{0}, local_num_atoms{local.num_local} {
+  auto r_brav = crystal.bravais;
+  auto k_brav = crystal.bravais;
+
+  // Scaling factors for the optimal truncation sphere
+  scaling_factor = lsms::scaling_factor(crystal.bravais, lmax);
+
+  r_brav.scale(1.0 / scaling_factor);
+  reciprocal_lattice(r_brav, k_brav, scaling_factor);
+
+  // Calculate truncation spheres
+  auto eta = lsms::calculate_eta(r_brav);
+
+  // Real-space cutoffs
+  r_nm = lsms::real_space_multiplication(r_brav, lmax, eta);
+  rscut = lsms::rs_trunc_radius(r_brav, lmax, eta, r_nm);
+  nrslat = num_latt_vectors(r_brav, rscut, r_nm);
+
+  // Reciprocal-space cutoffs
+  k_nm = lsms::reciprocal_space_multiplication(k_brav, lmax, eta);
+  kncut = lsms::kn_trunc_radius(k_brav, lmax, eta, k_nm);
+  nknlat = num_latt_vectors(k_brav, kncut, k_nm);
+
+  if (lsms.global.iprint > 1) {
+    std::printf("Madelung: %d %d %d: %lf %d\n", r_nm[0], r_nm[1], r_nm[2],
+                rscut, nrslat);
+    std::printf("Madelung: %d %d %d: %lf %d\n", k_nm[0], k_nm[1], k_nm[2],
+                kncut, nknlat);
+  }
+
+  // Create the lattice vectors
+  matrix<double> rslat;
+  std::vector<double> rslatsq;
+
+  matrix<double> knlat;
+  std::vector<double> knlatsq;
+
+  std::tie(rslat, rslatsq) =
+      lsms::create_lattice_and_sq(r_brav, rscut, r_nm, nrslat);
+
+  std::tie(knlat, knlatsq) =
+      lsms::create_lattice_and_sq(k_brav, kncut, k_nm, nknlat);
+
+  /*
+   * Calculate Madelung matrix for monopoles (lmax = 0)
+   */
+  auto omega = lsms::omega(r_brav);
+
+  std::vector<double> aij(3);
+  double r0tm;
+  int ibegin;
+
+  // Zero terms
+  auto term0 = -M_PI * eta * eta / omega;
+
+  for (auto j = 0; j < local.num_local; j++) {
+    local.atom[j].madelungMatrix.resize(crystal.num_atoms);
+  }
+
+  for (auto atom_i = 0; atom_i < num_atoms; atom_i++) {
+    for (auto local_i = 0; local_i < local_num_atoms; local_i++) {
+      auto global_i = local.global_id[local_i];
+
+      // a_ij in unit of a0
+      for (int idx = 0; idx < 3; idx++) {
+        aij[idx] = crystal.position(idx, atom_i) / scaling_factor -
+                   crystal.position(idx, global_i) / scaling_factor;
+      }
+
+      // Real space terms: first terms
+      if (global_i == atom_i) {
+        ibegin = 1;
+        r0tm = -2.0 / std::sqrt(M_PI) / eta;
+      } else {
+        ibegin = 0;
+        r0tm = 0.0;
+      }
+
+      // Reciprocal space term
+      auto term1 =
+          reciprocal_space_term(knlat, knlatsq, aij, nknlat, eta, omega);
+
+      // Real space term
+      auto term2 = real_space_term(rslat, aij, nrslat, ibegin, eta);
+
+      // Madelung matrix contribution
+      local.atom[local_i].madelungMatrix[atom_i] =
+          (term1 + term2 + r0tm + term0) / scaling_factor;
+    }
+  }
+}
+
+double lsms::MultipoleMadelung::getScalingFactor() const {
+  return scaling_factor;
+}
+
+double lsms::MultipoleMadelung::getRsCut() const { return rscut; }
+
+double lsms::MultipoleMadelung::getKnCut() const { return kncut; }
+
+std::vector<int> lsms::MultipoleMadelung::getKnSize() const { return k_nm; }
+
+std::vector<int> lsms::MultipoleMadelung::getRsSize() const { return r_nm; }

--- a/src/MultipoleMadelung/MultipoleMadelung.hpp
+++ b/src/MultipoleMadelung/MultipoleMadelung.hpp
@@ -1,0 +1,55 @@
+//
+// Created by F.Moitzi on 16.12.2021.
+//
+
+#ifndef MADELUNG_MULTIPOLEMADELUNG_HPP
+#define MADELUNG_MULTIPOLEMADELUNG_HPP
+
+#include <complex>
+#include <vector>
+
+#include "Main/SystemParameters.hpp"
+#include "common.hpp"
+
+namespace lsms {
+
+class MultipoleMadelung {
+ private:
+  /// Global number of atoms
+  int num_atoms;
+
+  /// Local number of atoms
+  int local_num_atoms;
+
+  double scaling_factor;
+  double rscut;
+  double kncut;
+
+  std::vector<int> r_nm;
+  int nrslat;
+
+  std::vector<int> k_nm;
+  int nknlat;
+
+ public:
+  /// Angular-momentum index cutoff l
+  int lmax;
+
+  /// Object for calculating the Madelung constants
+  MultipoleMadelung(LSMSSystemParameters &lsms, CrystalParameters &crystal,
+                    LocalTypeInfo &local);
+
+  double getScalingFactor() const;
+
+  double getRsCut() const;
+
+  double getKnCut() const;
+
+  std::vector<int> getRsSize() const;
+
+  std::vector<int> getKnSize() const;
+};
+
+}  // namespace lsms
+
+#endif  // MADELUNG_MULTIPOLEMADELUNG_HPP

--- a/src/MultipoleMadelung/calculateMultipoleMadelung.cpp
+++ b/src/MultipoleMadelung/calculateMultipoleMadelung.cpp
@@ -1,0 +1,17 @@
+//
+// Created by F.Moitzi on 19.01.2022.
+//
+
+#include "calculateMultipoleMadelung.hpp"
+
+#include "MultipoleMadelung.hpp"
+
+void calculateMultiMadelungMatrices(LSMSSystemParameters &lsms,
+                                    CrystalParameters &crystal,
+                                    LocalTypeInfo &local) {
+  if (lsms.global.iprint >= 0) {
+    std::printf("Madelung calculations!\n");
+  }
+
+  lsms::MultipoleMadelung madelung(lsms, crystal, local);
+}

--- a/src/MultipoleMadelung/calculateMultipoleMadelung.hpp
+++ b/src/MultipoleMadelung/calculateMultipoleMadelung.hpp
@@ -1,0 +1,9 @@
+//
+// Created by F.Moitzi on 19.01.2022.
+//
+
+#include "Main/SystemParameters.hpp"
+
+void calculateMultiMadelungMatrices(LSMSSystemParameters &lsms,
+                                    CrystalParameters &crystal,
+                                    LocalTypeInfo &local);

--- a/src/MultipoleMadelung/common.hpp
+++ b/src/MultipoleMadelung/common.hpp
@@ -1,0 +1,23 @@
+//
+// Created by F.Moitzi on 13.01.2022.
+//
+
+#ifndef SRC_MADELUNG_COMMON_HPP
+#define SRC_MADELUNG_COMMON_HPP
+
+#include "Array3d.hpp"
+#include "Matrix.hpp"
+
+constexpr auto Y0inv = 2.0 * 1.772453850905514;
+
+namespace lsms {
+
+template <typename T>
+using matrix = Matrix<T>;
+
+template <typename T>
+using array3d = Array3d<T>;
+
+}  // namespace lsms
+
+#endif  // SRC_MADELUNG_COMMON_HPP

--- a/src/MultipoleMadelung/debug.hpp
+++ b/src/MultipoleMadelung/debug.hpp
@@ -1,0 +1,13 @@
+//
+// Created by F.Moitzi on 20.12.2021.
+//
+
+#include <iostream>
+
+#define DEBUG
+
+#if defined(DEBUG)
+#define DEBUG_PRINT(args) std::cout << args << std : endl;
+#else
+#define DEBUG_PRINT(args)
+#endif

--- a/src/MultipoleMadelung/integer_factors.cpp
+++ b/src/MultipoleMadelung/integer_factors.cpp
@@ -1,0 +1,65 @@
+//
+// Created by F.Moitzi on 24.12.2021.
+//
+
+#include "integer_factors.hpp"
+
+std::vector<int> lsms::get_lofk(int l0) {
+  std::vector<int> lofk;
+
+  for (auto l = 0; l <= l0; l++) {
+    for (auto m = -l; m <= l; m++) {
+      lofk.emplace_back(l);
+    }
+  }
+
+  return lofk;
+}
+
+std::vector<int> lsms::get_mofk(int l0) {
+  std::vector<int> mofk;
+
+  for (auto l = 0; l <= l0; l++) {
+    for (auto m = -l; m <= l; m++) {
+      mofk.emplace_back(m);
+    }
+  }
+
+  return mofk;
+}
+
+std::vector<int> lsms::get_lofj(int l0) {
+  std::vector<int> lofj;
+
+  for (auto l = 0; l <= l0; l++) {
+    for (auto m = 0; m <= l; m++) {
+      lofj.emplace_back(l);
+    }
+  }
+
+  return lofj;
+}
+
+std::vector<int> lsms::get_mofj(int l0) {
+  std::vector<int> mofj;
+
+  for (auto l = 0; l <= l0; l++) {
+    for (auto m = 0; m <= l; m++) {
+      mofj.emplace_back(m);
+    }
+  }
+
+  return mofj;
+}
+
+std::vector<int> lsms::get_kofj(int l0) {
+  std::vector<int> kofj;
+
+  for (auto l = 0; l <= l0; l++) {
+    for (auto m = 0; m <= l; m++) {
+      kofj.emplace_back((l + 1) * (l + 1) - l + m - 1);
+    }
+  }
+
+  return kofj;
+}

--- a/src/MultipoleMadelung/integer_factors.hpp
+++ b/src/MultipoleMadelung/integer_factors.hpp
@@ -1,0 +1,37 @@
+//
+// Created by F.Moitzi on 24.12.2021.
+//
+
+#ifndef MADELUNG_INTEGER_FACTORS_HPP
+#define MADELUNG_INTEGER_FACTORS_HPP
+
+#include <type_traits>
+#include <vector>
+
+namespace lsms {
+
+std::vector<int> get_lofk(int l0);
+
+std::vector<int> get_mofk(int l0);
+
+std::vector<int> get_lofj(int l0);
+
+std::vector<int> get_mofj(int l0);
+
+std::vector<int> get_kofj(int l0);
+
+template <typename Integer,
+          typename = std::enable_if_t<std::is_integral<Integer>::value>>
+Integer get_jmax(Integer lmax) {
+  return (lmax + 1) * (lmax + 2) / 2;
+}
+
+template <typename Integer,
+          typename = std::enable_if_t<std::is_integral<Integer>::value>>
+Integer get_kmax(Integer lmax) {
+  return (lmax + 1) * (lmax + 1);
+}
+
+}  // namespace lsms
+
+#endif  // MADELUNG_INTEGER_FACTORS_HPP

--- a/src/MultipoleMadelung/lattice_utils.cpp
+++ b/src/MultipoleMadelung/lattice_utils.cpp
@@ -1,0 +1,150 @@
+//
+// Created by F.Moitzi on 21.12.2021.
+//
+
+#include "lattice_utils.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include "utils.hpp"
+
+double lsms::omega(lsms::matrix<double> &bravais) {
+  return std::abs(
+      (bravais(1, 0) * bravais(2, 1) - bravais(2, 0) * bravais(1, 1)) *
+          bravais(0, 2) +
+      (bravais(2, 0) * bravais(0, 1) - bravais(0, 0) * bravais(2, 1)) *
+          bravais(1, 2) +
+      (bravais(0, 0) * bravais(1, 1) - bravais(1, 0) * bravais(0, 1)) *
+          bravais(2, 2));
+}
+
+void lsms::insert_ordered(lsms::matrix<double> &latt_vec,
+                          std::vector<double> &latt_vec_sq, int len,
+                          std::vector<double> &vec, double &v_sq) {
+  for (int i = 0; i < len; i++) {
+    if (latt_vec_sq[i] >= v_sq) {
+      for (int j = len - 1; j >= i; j--) {
+        latt_vec(0, j + 1) = latt_vec(0, j);
+        latt_vec(1, j + 1) = latt_vec(1, j);
+        latt_vec(2, j + 1) = latt_vec(2, j);
+        latt_vec_sq[j + 1] = latt_vec_sq[j];
+      }
+
+      latt_vec_sq[i] = v_sq;
+
+      latt_vec(0, i) = vec[0];
+      latt_vec(1, i) = vec[1];
+      latt_vec(2, i) = vec[2];
+
+      return;
+    }
+  }
+
+  latt_vec_sq[len] = v_sq;
+  latt_vec(0, len) = vec[0];
+  latt_vec(1, len) = vec[1];
+  latt_vec(2, len) = vec[2];
+}
+
+lsms::matrix<double> lsms::create_lattice(const lsms::matrix<double> &brav,
+                                          double cutoff,
+                                          const std::vector<int> &nm,
+                                          int size) {
+  lsms::matrix<double> latt_vec(3, size);
+  std::vector<double> latt_vec_sq(size);
+
+  int number = 0;
+
+  // To also include vectors on the boarder
+  double vcut2 = cutoff * cutoff + 1e-6;
+
+  std::vector<double> vn(3, 0.0);
+
+  for (int x = -nm[0]; x <= nm[0]; x++) {
+    for (int y = -nm[1]; y <= nm[1]; y++) {
+      for (int z = -nm[2]; z <= nm[2]; z++) {
+        vn[0] = x * brav(0, 0) + y * brav(0, 1) + z * brav(0, 2);
+        vn[1] = x * brav(1, 0) + y * brav(1, 1) + z * brav(1, 2);
+        vn[2] = x * brav(2, 0) + y * brav(2, 1) + z * brav(2, 2);
+
+        auto norm = norm_sq(vn.begin(), vn.end());
+
+        if (norm <= vcut2) {
+          insert_ordered(latt_vec, latt_vec_sq, number, vn, norm);
+          number++;
+        }
+      }
+    }
+  }
+
+  return latt_vec;
+}
+
+std::tuple<lsms::matrix<double>, std::vector<double>>
+lsms::create_lattice_and_sq(lsms::matrix<double> &brav, double cutoff,
+                            const std::vector<int> &nm, int size) {
+  lsms::matrix<double> latt_vec(3, size);
+  std::vector<double> latt_vec_sq(size);
+
+  int number = 0;
+
+  // To also include vectors on the boarder
+  double vcut2 = cutoff * cutoff + 1e-6;
+
+  std::vector<double> vn(3, 0.0);
+
+  for (int x = -nm[0]; x <= nm[0]; x++) {
+    for (int y = -nm[1]; y <= nm[1]; y++) {
+      for (int z = -nm[2]; z <= nm[2]; z++) {
+        vn[0] = x * brav(0, 0) + y * brav(0, 1) + z * brav(0, 2);
+        vn[1] = x * brav(1, 0) + y * brav(1, 1) + z * brav(1, 2);
+        vn[2] = x * brav(2, 0) + y * brav(2, 1) + z * brav(2, 2);
+
+        auto norm = norm_sq(vn.begin(), vn.end());
+
+        if (norm <= vcut2) {
+          insert_ordered(latt_vec, latt_vec_sq, number, vn, norm);
+          number++;
+        }
+      }
+    }
+  }
+
+  return std::make_tuple(latt_vec, latt_vec_sq);
+}
+
+void lsms::reciprocal_lattice(lsms::matrix<double> &bravais,
+                              lsms::matrix<double> &reciprocal_bravais,
+                              double &scale) {
+  auto vol = (bravais(1, 0) * bravais(2, 1) - bravais(2, 0) * bravais(1, 1)) *
+                 bravais(0, 2) +
+             (bravais(2, 0) * bravais(0, 1) - bravais(0, 0) * bravais(2, 1)) *
+                 bravais(1, 2) +
+             (bravais(0, 0) * bravais(1, 1) - bravais(1, 0) * bravais(0, 1)) *
+                 bravais(2, 2);
+
+  auto factor = 2.0 * M_PI / fabs(vol);
+
+  reciprocal_bravais(0, 0) =
+      factor * (bravais(1, 1) * bravais(2, 2) - bravais(2, 1) * bravais(1, 2));
+  reciprocal_bravais(1, 0) =
+      factor * (bravais(2, 1) * bravais(0, 2) - bravais(0, 1) * bravais(2, 2));
+  reciprocal_bravais(2, 0) =
+      factor * (bravais(0, 1) * bravais(1, 2) - bravais(1, 1) * bravais(0, 2));
+
+  reciprocal_bravais(0, 1) =
+      factor * (bravais(1, 2) * bravais(2, 0) - bravais(2, 2) * bravais(1, 0));
+  reciprocal_bravais(1, 1) =
+      factor * (bravais(2, 2) * bravais(0, 0) - bravais(0, 2) * bravais(2, 0));
+  reciprocal_bravais(2, 1) =
+      factor * (bravais(0, 2) * bravais(1, 0) - bravais(1, 2) * bravais(0, 0));
+
+  reciprocal_bravais(0, 2) =
+      factor * (bravais(1, 0) * bravais(2, 1) - bravais(2, 0) * bravais(1, 1));
+  reciprocal_bravais(1, 2) =
+      factor * (bravais(2, 0) * bravais(0, 1) - bravais(0, 0) * bravais(2, 1));
+  reciprocal_bravais(2, 2) =
+      factor * (bravais(0, 0) * bravais(1, 1) - bravais(1, 0) * bravais(0, 1));
+}

--- a/src/MultipoleMadelung/lattice_utils.hpp
+++ b/src/MultipoleMadelung/lattice_utils.hpp
@@ -1,0 +1,48 @@
+//
+// Created by F.Moitzi on 21.12.2021.
+//
+
+#ifndef MADELUNG_LATTICE_HPP
+#define MADELUNG_LATTICE_HPP
+
+#include <complex>
+#include <tuple>
+#include <vector>
+
+#include "common.hpp"
+
+namespace lsms {
+
+/**
+ * Create all vectors in certain cutoff with a certain repeotition
+ */
+matrix<double> create_lattice(const matrix<double> &brav, double cutoff,
+                              const std::vector<int> &nm, int size);
+
+/**
+ * Create all vectors in certain cutoff with a certain repeotition
+ */
+std::tuple<matrix<double>, std::vector<double>> create_lattice_and_sq(
+    matrix<double> &brav, double cutoff, const std::vector<int> &nm, int size);
+
+/**
+ *  inserts a vector in a list of vectors such that they are in
+ *  order of increasing length.
+ */
+void insert_ordered(matrix<double> &latt_vec, std::vector<double> &latt_vec_sq,
+                    int len, std::vector<double> &vec, double &v_sq);
+
+/**
+ * Lattice volumes
+ */
+double omega(matrix<double> &bravais);
+
+/**
+ * Calculate reciprocal lattice
+ */
+void reciprocal_lattice(matrix<double> &bravais,
+                        matrix<double> &reciprocal_bravais, double &scale);
+
+}  // namespace lsms
+
+#endif  // MADELUNG_LATTICE_HPP

--- a/src/MultipoleMadelung/madelung_term.hpp
+++ b/src/MultipoleMadelung/madelung_term.hpp
@@ -30,7 +30,7 @@ namespace lsms {
  */
 template <class T>
 inline T reciprocal_space_term(matrix<T> &knlat, std::vector<T> &knlatsq,
-                               std::vector<T> aij, int nknlat, double eta,
+                               std::vector<T> &aij, int nknlat, double eta,
                                double omega) {
   auto term12 = 0.0;
   auto fac = eta * eta / 4.0;
@@ -58,7 +58,7 @@ inline T reciprocal_space_term(matrix<T> &knlat, std::vector<T> &knlatsq,
  *
  */
 template <class T>
-inline T real_space_term(matrix<T> &rslat, std::vector<T> aij, int nrslat,
+inline T real_space_term(matrix<T> &rslat, std::vector<T> &aij, int nrslat,
                          int ibegin, T eta) {
   /*
    *  subtract aij from rslat and calculate rslatmd which is used in

--- a/src/MultipoleMadelung/madelung_term.hpp
+++ b/src/MultipoleMadelung/madelung_term.hpp
@@ -1,0 +1,88 @@
+//
+// Created by F.Moitzi on 07.01.2022.
+//
+
+#ifndef SRC_MADELUNG_MADELUNG_TERM_HPP
+#define SRC_MADELUNG_MADELUNG_TERM_HPP
+
+#include <algorithm>
+#include <complex>
+#include <numeric>
+#include <vector>
+
+#include "common.hpp"
+#include "utils.hpp"
+
+namespace lsms {
+
+/**
+ * Reciprocal space term of Madelung sum:
+ *
+ *                                       2   2       -> ->
+ *                4*pi          1    -eta *Kq /4 - i*Kq*aij
+ *       term1 =  ---- * sum  ----- e
+ *                tau    q<>0    2
+ *                             Kq
+ *
+ *       note sum starts at 2 since kn=0.0 of 1/(rs-aij) is
+ *       canceled by kn=0.0 of the 1/rs sum.
+ *
+ */
+template <class T>
+inline T reciprocal_space_term(matrix<T> &knlat, std::vector<T> &knlatsq,
+                               std::vector<T> aij, int nknlat, double eta,
+                               double omega) {
+  auto term12 = 0.0;
+  auto fac = eta * eta / 4.0;
+
+  for (auto i = nknlat - 1; i > 0; i--) {
+    term12 += std::exp(-fac * knlatsq[i]) / knlatsq[i] *
+              std::cos(knlat(0, i) * aij[0] + knlat(1, i) * aij[1] +
+                       knlat(2, i) * aij[2]);
+  }
+  term12 = 4.0 * M_PI / omega * term12;
+
+  return term12;
+}
+
+/**
+ * Real space term of Madelung sum:
+ *
+ *                              ->   ->
+ *                     1 - erf(|Rn + aij|/eta)
+ *        term2 = sum -------------------------
+ *                 n         ->   ->
+ *                         |Rn + aij|
+ *
+ *        note for calculation of aij=0.0 term ibegin=2.
+ *
+ */
+template <class T>
+inline T real_space_term(matrix<T> &rslat, std::vector<T> aij, int nrslat,
+                         int ibegin, T eta) {
+  /*
+   *  subtract aij from rslat and calculate rslatmd which is used in
+   *  calculating the real-space integral
+   *  rslatmd, and aij are in the units of a0 = 1
+   */
+
+  std::vector<T> rslatmd(nrslat);
+
+  for (auto i = 0; i < nrslat; i++) {
+    rslatmd[i] = std::sqrt((rslat(0, i) - aij[0]) * (rslat(0, i) - aij[0]) +
+                           (rslat(1, i) - aij[1]) * (rslat(1, i) - aij[1]) +
+                           (rslat(2, i) - aij[2]) * (rslat(2, i) - aij[2]));
+  }
+
+  auto rterm = 0.0;
+
+  for (auto i = nrslat - 1; i >= ibegin; i--) {
+    rterm += std::erfc(rslatmd[i] / eta) / rslatmd[i];
+  }
+
+  return rterm;
+}
+
+}  // namespace lsms
+
+#endif  // SRC_MADELUNG_MADELUNG_TERM_HPP

--- a/src/MultipoleMadelung/monopole_madelung.cpp
+++ b/src/MultipoleMadelung/monopole_madelung.cpp
@@ -1,0 +1,245 @@
+//
+// Created by F.Moitzi on 06.01.2022.
+//
+
+#include "monopole_madelung.hpp"
+
+#define _USE_MATH_DEFINES
+
+#include <algorithm>
+#include <cmath>
+
+#include "integer_factors.hpp"
+#include "lattice_utils.hpp"
+#include "madelung_term.hpp"
+#include "utils.hpp"
+
+double lsms::scaling_factor(const lsms::matrix<double> &bravais, int lmax,
+                            int max_iter, double fstep) {
+  // Scaled bravais lattice
+  lsms::matrix<double> r_brav(3, 3);
+  // Scaled reciprocal lattice
+  lsms::matrix<double> k_brav(3, 3);
+
+  // Get the shortest axis
+  auto a0 =
+      std::sqrt(bravais(0, 0) * bravais(0, 0) + bravais(1, 0) * bravais(1, 0) +
+                bravais(2, 0) * bravais(2, 0));
+
+  auto a1 =
+      std::sqrt(bravais(0, 1) * bravais(0, 1) + bravais(1, 1) * bravais(1, 1) +
+                bravais(2, 1) * bravais(2, 1));
+
+  auto a2 =
+      std::sqrt(bravais(0, 2) * bravais(0, 2) + bravais(1, 2) * bravais(1, 2) +
+                bravais(2, 2) * bravais(2, 2));
+
+  double scaling_fac = std::min({a0, a1, a2});
+  auto eta = 0.5 + 0.1 * std::max({a0, a1, a2}) / scaling_fac;
+  scaling_fac /= 2.0 * M_PI;
+
+  std::vector<int> nm(3);
+
+  for (int i = 0; i <= max_iter; i++) {
+    r_brav = bravais;
+    r_brav.scale(1 / scaling_fac);
+    k_brav = 0.0;
+
+    reciprocal_lattice(r_brav, k_brav, scaling_fac);
+
+    // Radius of real space truncation sphere
+    nm = real_space_multiplication(r_brav, lmax, eta);
+    auto rscut = rs_trunc_radius(r_brav, lmax, eta, nm);
+#ifdef LSMS_DEBUG
+    std::cout << nm[0] << " " << nm[1] << " " << nm[2] << std::endl;
+#endif
+
+    // Calculate number of lattice vectors
+    auto nrslat = num_latt_vectors(r_brav, rscut, nm);
+
+    // Radius of reciprocal space
+    nm = reciprocal_space_multiplication(k_brav, lmax, eta);
+    auto kncut = kn_trunc_radius(k_brav, lmax, eta, nm);
+#ifdef LSMS_DEBUG
+    std::cout << nm[0] << " " << nm[1] << " " << nm[2] << std::endl;
+#endif
+
+    // Calculate number of lattice vectors
+    auto nknlat = num_latt_vectors(k_brav, kncut, nm);
+
+#ifdef LSMS_DEBUG
+    std::printf("ALAT: %f %f %f\n", r_brav(0, 0), r_brav(1, 1), r_brav(2, 2));
+    std::printf("RS: %f KN: %f RSLAT: %d KNLAT: %d SC: %f\n", rscut, kncut,
+                nrslat, nknlat, scaling_fac);
+#endif
+
+    if (nknlat < nrslat / 2) {
+      scaling_fac = scaling_fac - fstep;
+    } else if (nrslat < nknlat / 2) {
+      scaling_fac = scaling_fac + fstep;
+    } else {
+      break;
+    }
+  }
+
+  return scaling_fac;
+}
+
+int lsms::num_latt_vectors(const lsms::matrix<double> &brav, double cut,
+                           const std::vector<int> &nm) {
+  int number = 0;
+
+  // To also include vectors on the boarder
+  double vcut2 = cut * cut + 1e-6;
+
+  std::vector<double> vn(3, 0.0);
+
+  for (int x = -nm[0]; x <= nm[0]; x++) {
+    for (int y = -nm[1]; y <= nm[1]; y++) {
+      for (int z = -nm[2]; z <= nm[2]; z++) {
+        vn[0] = x * brav(0, 0) + y * brav(0, 1) + z * brav(0, 2);
+        vn[1] = x * brav(1, 0) + y * brav(1, 1) + z * brav(1, 2);
+        vn[2] = x * brav(2, 0) + y * brav(2, 1) + z * brav(2, 2);
+
+        auto norm = norm_sq(vn.begin(), vn.end());
+
+        if (norm <= vcut2) {
+          number++;
+        }
+      }
+    }
+  }
+
+  return number;
+}
+
+std::vector<int> lsms::real_space_multiplication(
+    const lsms::matrix<double> &brav, int lmax, double eta) {
+  std::vector<int> nm(3);
+  std::vector<double> r(3, 0.0);
+
+  for (int i = 0; i < 3; i++) {
+    r[i] = std::sqrt(brav(0, i) * brav(0, i) + brav(1, i) * brav(1, i) +
+                     brav(2, i) * brav(2, i));
+  }
+
+  for (int i = 0; i < 3; i++) {
+    nm[i] = 0;
+    auto term = 1.0;
+    while (term > 0.5 * lsms::EPSI) {
+      nm[i]++;
+      auto gamma = gamma_func(nm[i] * r[i] / eta, lmax);
+      term = gamma[lmax] / std::pow((nm[i] * r[i] / 2.0), lmax + 1);
+    }
+  }
+
+  return nm;
+}
+
+double lsms::rs_trunc_radius(const lsms::matrix<double> &brav, int lmax,
+                             double eta, const std::vector<int> &nm) {
+  auto cut = 0.0;
+
+  std::vector<double> r(3, 0.0);
+
+  for (int i = 0; i < 3; i++) {
+    r[i] = sqrt(brav(0, i) * brav(0, i) + brav(1, i) * brav(1, i) +
+                brav(2, i) * brav(2, i));
+  }
+
+  for (int i = -1; i <= 1; i++) {
+    for (int idx = 0; idx < 3; idx++) {
+      r[idx] = i * brav(idx, 0) * nm[0];
+    }
+
+    for (int j = -1; j <= 1; j++) {
+      for (int idx = 0; idx < 3; idx++) {
+        r[idx] = r[idx] + j * brav(idx, 1) * nm[1];
+      }
+
+      for (int k = -1; k <= 1; k++) {
+        for (int idx = 0; idx < 3; idx++) {
+          r[idx] = r[idx] + k * brav(idx, 2) * nm[2];
+        }
+
+        cut = std::max(cut, norm(r.begin(), r.end()));
+      }
+    }
+  }
+
+  return cut;
+}
+
+double lsms::kn_trunc_radius(const lsms::matrix<double> &brav, int lmax,
+                             double eta, const std::vector<int> &nm) {
+  auto cut = 0.0;
+
+  std::vector<double> r(3, 0.0);
+
+  for (int i = 0; i < 3; i++) {
+    r[i] = sqrt(brav(0, i) * brav(0, i) + brav(1, i) * brav(1, i) +
+                brav(2, i) * brav(2, i));
+  }
+
+  for (int i = -1; i <= 1; i++) {
+    for (int idx = 0; idx < 3; idx++) {
+      r[idx] = i * brav(idx, 0) * nm[0];
+    }
+
+    for (int j = -1; j <= 1; j++) {
+      for (int idx = 0; idx < 3; idx++) {
+        r[idx] = r[idx] + j * brav(idx, 1) * nm[1];
+      }
+
+      for (int k = -1; k <= 1; k++) {
+        for (int idx = 0; idx < 3; idx++) {
+          r[idx] = r[idx] + k * brav(idx, 2) * nm[2];
+        }
+
+        cut = std::max(cut, norm(r.begin(), r.end()));
+      }
+    }
+  }
+
+  return cut;
+}
+
+std::vector<int> lsms::reciprocal_space_multiplication(
+    const lsms::matrix<double> &brav, int lmax, double eta) {
+  std::vector<int> nm(3);
+  std::vector<double> r(3, 0.0);
+
+  for (int i = 0; i < 3; i++) {
+    r[i] = brav(0, i) * brav(0, i) + brav(1, i) * brav(1, i) +
+           brav(2, i) * brav(2, i);
+  }
+
+  auto fac = eta * eta / 4.0;
+
+  for (int i = 0; i < 3; i++) {
+    nm[i] = 0;
+    auto term = 1.0;
+    while (term > 0.5 * lsms::EPSI) {
+      nm[i]++;
+      auto rm = nm[i] * nm[i] * r[i];
+      term = exp(-fac * rm) * std::pow(sqrt(rm), lmax - 2);
+    }
+  }
+
+  return nm;
+}
+
+double lsms::calculate_eta(lsms::matrix<double> &bravais) {
+  auto a0 = sqrt(bravais(0, 0) * bravais(0, 0) + bravais(1, 0) * bravais(1, 0) +
+                 bravais(2, 0) * bravais(2, 0));
+
+  auto a1 = sqrt(bravais(0, 1) * bravais(0, 1) + bravais(1, 1) * bravais(1, 1) +
+                 bravais(2, 1) * bravais(2, 1));
+
+  auto a2 = sqrt(bravais(0, 2) * bravais(0, 2) + bravais(1, 2) * bravais(1, 2) +
+                 bravais(2, 2) * bravais(2, 2));
+
+  auto scaling_fac = std::min({a0, a1, a2});
+
+  return 0.5 + 0.1 * std::max({a0, a1, a2}) / scaling_fac;
+}

--- a/src/MultipoleMadelung/monopole_madelung.hpp
+++ b/src/MultipoleMadelung/monopole_madelung.hpp
@@ -1,0 +1,58 @@
+//
+// Created by F.Moitzi on 06.01.2022.
+//
+
+#ifndef SRC_MADELUNG_MADELUNG_HPP
+#define SRC_MADELUNG_MADELUNG_HPP
+
+#include <complex>
+#include <vector>
+
+#include "common.hpp"
+
+namespace lsms {
+
+constexpr auto EPSI = 1e-14;
+
+/**
+ * Calculate the scaling factor to get a balanced number
+ * of reciprocal and real-space lattice vectors
+ */
+double scaling_factor(const matrix<double> &bravais, int lmax,
+                      int max_iter = 100, double fstep = 0.02);
+
+/**
+ * Number of lattice vectors
+ */
+int num_latt_vectors(const matrix<double> &brav, double cut,
+                     const std::vector<int> &nm);
+
+/**
+ * Get radius of truncation sphere
+ */
+double rs_trunc_radius(const matrix<double> &brav, int lmax, double eta,
+                       const std::vector<int> &nm);
+
+double kn_trunc_radius(const matrix<double> &brav, int lmax, double eta,
+                       const std::vector<int> &nm);
+
+/**
+ * Get size of lattice multiplications
+ */
+std::vector<int> real_space_multiplication(const matrix<double> &brav, int lmax,
+                                           double eta);
+
+/**
+ * Get size of reciprocal lattice multiplications
+ */
+std::vector<int> reciprocal_space_multiplication(const matrix<double> &brav,
+                                                 int lmax, double eta);
+
+/**
+ * Calculate the `\eta` factor
+ */
+double calculate_eta(matrix<double> &brav);
+
+}  // namespace lsms
+
+#endif  // SRC_MADELUNG_MADELUNG_HPP

--- a/src/MultipoleMadelung/utils.hpp
+++ b/src/MultipoleMadelung/utils.hpp
@@ -1,0 +1,63 @@
+//
+// Created by F.Moitzi on 17.12.2021.
+//
+
+#ifndef MADELUNG_UTILS_HPP
+#define MADELUNG_UTILS_HPP
+
+#define _USE_MATH_DEFINES
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+template <typename Iter_T>
+auto norm(Iter_T first, Iter_T last) {
+  return std::sqrt(std::inner_product(first, last, first, 0.0));
+}
+
+template <typename Iter_T>
+auto norm_sq(Iter_T first, Iter_T last) {
+  return std::inner_product(first, last, first, 0.0);
+}
+
+/**
+ *
+ *  call calGammaFunc to calculate the integral:
+ *
+ *         inf       2*l
+ *  I(l) = int dx * x   * exp(-x**2)
+ *          a
+ *
+ *  and store it in gamma_l(l)
+ *
+ *  l = 0, 1, ..., lmax.
+ *
+ *  using: (2*l+1)*I(l) = 2*I(l+1) - c(l) ,
+ *
+ *
+ *         c(l) = a**(2*l+1) * exp(-a**2)
+ *
+ *         I(0) = sqrt(pi)/2 * erfc(a)
+ *
+ *  erfc(z) = 1 - erf(z)
+ */
+template <class T>
+std::vector<T> gamma_func(const T &&a, int &lmax) {
+  auto r_factor = 0.5 * std::exp(-a * a);
+
+  std::vector<T> gamma(lmax + 1, 0.0);
+
+  // l = 0
+  gamma[0] = std::sqrt(M_PI) * 0.5 * std::erfc(a);
+
+  for (int l = 1; l <= lmax; l++) {
+    gamma[l] =
+        0.5 * (2 * l - 1) * gamma[l - 1] + std::pow(a, (2 * l - 1)) * r_factor;
+  }
+
+  return gamma;
+}
+
+#endif  // MADELUNG_UTILS_HPP

--- a/toolchain/summit-gnu-cuda-release.cmake
+++ b/toolchain/summit-gnu-cuda-release.cmake
@@ -9,6 +9,8 @@
 
 message(STATUS "Use toolchain file")
 
+set(BUILD_TESTING OFF)
+
 set(USE_ACCELERATOR_CUDA_C ON)
 set(USE_ESSL ON)
 set(ARCH_IBM ON)


### PR DESCRIPTION
The current implementation of the Madelung constant calculation has issues with skewed and flat structures and is also hard to generalize for Multipoles, which are needed for FP and FCD. This PR fixes the issue that arises with certain structures by implementing a preliminary check for the matrix sizes needed before allocation happens. Also unit tests are added.

- Add a C++ version for the madelung constant calculation
- Prepare for multipole calculations