### PR TITLE
Add global output for each contribution to the DFT

### DIFF
--- a/src/Main/lsms.cpp
+++ b/src/Main/lsms.cpp
@@ -93,7 +93,7 @@ feenableexcept (unsigned int excepts)
 
   return ( fesetenv (&fenv) ? -1 : old_excepts );
 }
-*/ 
+*/
 
 
 int main(int argc, char *argv[])
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
 #ifdef LSMS_DEBUG
   MPI_Barrier(comm.comm);
 #endif
- 
+
   communicateParameters(comm, lsms, crystal, mix, alloyDesc);
   if (comm.rank != lsms.global.print_node)
     lsms.global.iprint = lsms.global.default_iprint;
@@ -209,11 +209,11 @@ int main(int argc, char *argv[])
 
   local.setNumLocal(distributeTypes(crystal, comm));
   local.setGlobalId(comm.rank, crystal);
-     
+
 #if defined(ACCELERATOR_CUDA_C) || defined(ACCELERATOR_HIP)
   deviceAtoms.resize(local.num_local);
 #endif
-     
+
   if(comm.rank == 0)
   {
     printf("set global ids.\n");
@@ -276,7 +276,7 @@ int main(int argc, char *argv[])
 #endif
 
   for (int i=0; i<local.num_local; i++)
-    local.atom[i].pmat_m.resize(lsms.energyContour.groupSize());  
+    local.atom[i].pmat_m.resize(lsms.energyContour.groupSize());
 
 // set maximal number of radial grid points and core states if reading from bigcell file
   local.setMaxPts(lsms.global.iprpts);
@@ -350,7 +350,7 @@ int main(int argc, char *argv[])
       printf("Entering the LOADING of the alloy banks.\n");
       fflush(stdout);
     }
-    loadAlloyBank(comm,lsms,alloyDesc,alloyBank); 
+    loadAlloyBank(comm,lsms,alloyDesc,alloyBank);
   }
 
 // for testing purposes:
@@ -494,7 +494,7 @@ int main(int argc, char *argv[])
   int iteration;
 #ifdef USE_NVTX
   nvtxRangePushA("SCFLoop");
-#endif  
+#endif
   for (iteration=0; iteration<lsms.nscf && !(converged && energyConverged); iteration++)
   {
     if (lsms.global.iprint >= -1 && comm.rank == 0)
@@ -520,11 +520,11 @@ int main(int argc, char *argv[])
     {
       if(!mix.quantity[MixingParameters::moment_direction])
         local.atom[i].newConstraint();
-      
+
       local.atom[i].evec[0] = local.atom[i].evecNew[0];
       local.atom[i].evec[1] = local.atom[i].evecNew[1];
       local.atom[i].evec[2] = local.atom[i].evecNew[2];
-      
+
       checkIfSpinHasFlipped(lsms, local.atom[i]);
     }
 
@@ -546,11 +546,11 @@ int main(int argc, char *argv[])
 
     // Calculate charge density rms
     calculateLocalQrms(lsms, local);
-    
+
     // Mix charge density
     mixing -> updateChargeDensity(comm, lsms, local.atom);
     dTimePM = MPI_Wtime() - dTimePM;
-    timeCalcPotentialsAndMixing += dTimePM; 
+    timeCalcPotentialsAndMixing += dTimePM;
 
     // pf = fopen("vr_test_3.dat","w");
     // printAtomPotential(pf, local.atom[0]);
@@ -582,7 +582,7 @@ int main(int argc, char *argv[])
     // fclose(pf);
 
     mixing -> updatePotential(comm, lsms, local.atom);
-    
+
     // pf = fopen("vr_test_6.dat","w");
     // printAtomPotential(pf, local.atom[0]);
     // fclose(pf);
@@ -607,7 +607,7 @@ int main(int argc, char *argv[])
         rms = std::max(rms, local.atom[i].qrms[0]);
       globalMax(comm, rms);
     }
-    
+
 // check for convergence
     converged = rms < lsms.rmsTolerance;
     /*
@@ -661,7 +661,7 @@ int main(int argc, char *argv[])
       writePotentials(comm, lsms, crystal, local);
       potentialWriteCounter = 0;
       if (comm.rank == 0)
-      { 
+      {
         writeRestart("i_lsms.restart", lsms, crystal, mix, potentialShifter, alloyDesc);
       }
     }
@@ -671,7 +671,7 @@ int main(int argc, char *argv[])
   nvtxRangePop();
 #endif
   timeScfLoop = MPI_Wtime() - timeScfLoop;
-  
+
   writeInfoEvec(comm, lsms, crystal, local, eband, lsms.infoEvecFileOut);
   if(lsms.localAtomDataFile[0]!=0)
     writeLocalAtomData(comm, lsms, crystal, local, eband, lsms.localAtomDataFile);
@@ -679,7 +679,17 @@ int main(int argc, char *argv[])
   if (kFile != NULL)
     fclose(kFile);
 
- 
+  /**
+   * Total energy calculation of all contributions
+   */
+
+  lsms::DFTEnergy dft_energy;
+  calculateTotalEnergy(comm, lsms, local, crystal, dft_energy);
+
+  if (comm.rank == 0)
+  {
+    lsms::print_dft_energy( dft_energy);
+  }
 
 // -----------------------------------------------------------------------------
 

--- a/src/TotalEnergy/CMakeLists.txt
+++ b/src/TotalEnergy/CMakeLists.txt
@@ -8,6 +8,8 @@ target_sources(lsmscore
         localTotalEnergy.hpp
         zeropt_c.f
         janake_c.f
+        DFTEnergy.cpp
+        DFTEnergy.hpp
         )
 
 target_include_directories(

--- a/src/TotalEnergy/DFTEnergy.cpp
+++ b/src/TotalEnergy/DFTEnergy.cpp
@@ -1,0 +1,130 @@
+//
+// Created by F.Moitzi on 05.07.2022.
+//
+
+#include "DFTEnergy.hpp"
+
+#include <mpi.h>
+
+template<class T>
+static int num_digits(T number) {
+  int digits = 0;
+
+  //if (number < 0) digits = 1; // remove this line if '-' counts as a digit
+
+  while (number) {
+    number /= 10;
+    digits++;
+  }
+  return digits;
+}
+
+void lsms::print_dft_energy(const DFTEnergy &energy) {
+
+  int size = -1;
+
+  size = std::max(size, num_digits(static_cast<int> (energy.core_eigen)));
+  size = std::max(size, num_digits(static_cast<int> (energy.semicore_eigen)));
+  size = std::max(size, num_digits(static_cast<int> (energy.one_ele)));
+  size = std::max(size, num_digits(static_cast<int> (energy.ks)));
+  size = std::max(size, num_digits(static_cast<int> (energy.kinetic)));
+  size = std::max(size, num_digits(static_cast<int> (energy.hartree)));
+  size = std::max(size, num_digits(static_cast<int> (energy.core_hartree)));
+  size = std::max(size, num_digits(static_cast<int> (energy.coloumb)));
+  size = std::max(size, num_digits(static_cast<int> (energy.kinetic)));
+  size = std::max(size, num_digits(static_cast<int> (energy.hartree)));
+  size = std::max(size, num_digits(static_cast<int> (energy.core_hartree)));
+  size = std::max(size, num_digits(static_cast<int> (energy.coloumb)));
+  size = std::max(size, num_digits(static_cast<int> (energy.xc)));
+  size = std::max(size, num_digits(static_cast<int> (energy.zero_point)));
+  size = std::max(size, num_digits(static_cast<int> (energy.lsf)));
+  size = std::max(size, num_digits(static_cast<int> (energy.madelung)));
+  size = std::max(size, num_digits(static_cast<int> (energy.shift)));
+  size = std::max(size, num_digits(static_cast<int> (energy.total)));
+
+  size += 12;
+
+  std::printf("===================\n");
+
+  std::printf("%-12s = %*.10f Ry\n", "Core", size, energy.core_eigen);
+  std::printf("%-12s = %*.10f Ry\n", "Semicore", size, energy.semicore_eigen);
+  std::printf("%-12s = %*.10f Ry\n", "One electron", size, energy.one_ele);
+  std::printf("%-12s = %*.10f Ry\n", "Kohn-Sham", size, energy.ks);
+  std::printf("%-12s = %*.10f Ry\n", "Kinetic", size, energy.kinetic);
+
+  std::printf("%-12s = %*.10f Ry\n", "Hartree", size, energy.hartree);
+  std::printf("%-12s = %*.10f Ry\n", "Core Hartree", size, energy.core_hartree);
+  std::printf("%-12s = %*.10f Ry\n", "Coloumb", size, energy.coloumb);
+
+  std::printf("%-12s = %*.10f Ry\n", "XC", size, energy.xc);
+  std::printf("%-12s = %*.10f Ry\n", "ZPE", size, energy.zero_point);
+  std::printf("%-12s = %*.10f Ry\n", "LSF", size, energy.lsf);
+
+  std::printf("%-12s = %*.10f Ry\n", "Madelung", size, energy.madelung);
+  std::printf("%-12s = %*.10f Ry\n", "MT Zero", size, energy.shift);
+
+  std::printf("%-12s = %*.10f Ry\n", "Total energy", size, energy.total);
+
+  std::printf("===================\n");
+
+}
+
+static void sum_dft_energies(lsms::DFTEnergy *in, lsms::DFTEnergy *inout,
+                             int *len, MPI_Datatype *type) {
+  for (int i = 0; i < *len; i++) {
+    inout[i] += in[i];
+  }
+}
+
+void lsms::globalSum(LSMSCommunication &comm, DFTEnergy &dft_energy) {
+  DFTEnergy global_dft_energy;
+
+  MPI_Datatype dft_type;
+
+  constexpr int size = 14;
+
+  std::vector<MPI_Datatype> types(size, MPI_DOUBLE);
+  std::vector<int> blocks(size, 1);
+  std::vector<MPI_Aint> displacements(size);
+  MPI_Aint base;
+
+  MPI_Get_address(&dft_energy, &base);
+  MPI_Get_address(&dft_energy.zero_point, &displacements[0]);
+  MPI_Get_address(&dft_energy.core_eigen, &displacements[1]);
+  MPI_Get_address(&dft_energy.semicore_eigen, &displacements[2]);
+  MPI_Get_address(&dft_energy.one_ele, &displacements[3]);
+  MPI_Get_address(&dft_energy.ks, &displacements[4]);
+  MPI_Get_address(&dft_energy.kinetic, &displacements[5]);
+  MPI_Get_address(&dft_energy.hartree, &displacements[6]);
+  MPI_Get_address(&dft_energy.core_hartree, &displacements[7]);
+  MPI_Get_address(&dft_energy.coloumb, &displacements[8]);
+  MPI_Get_address(&dft_energy.xc, &displacements[9]);
+  MPI_Get_address(&dft_energy.lsf, &displacements[10]);
+  MPI_Get_address(&dft_energy.total, &displacements[11]);
+  MPI_Get_address(&dft_energy.madelung, &displacements[12]);
+  MPI_Get_address(&dft_energy.shift, &displacements[13]);
+
+  for (auto &value: displacements) {
+    value -= base;
+  }
+
+  MPI_Type_create_struct(size, blocks.data(), displacements.data(),
+                         types.data(), &dft_type);
+
+  MPI_Type_commit(&dft_type);
+
+  MPI_Op dft_energy_sum;
+  MPI_Op_create(
+      reinterpret_cast<void (*)(void *, void *, int *, MPI_Datatype *)>(
+          sum_dft_energies),
+      1, &dft_energy_sum);
+
+  MPI_Allreduce(&dft_energy, &global_dft_energy, 1, dft_type, dft_energy_sum,
+                comm.comm);
+
+  MPI_Op_free(&dft_energy_sum);
+
+  dft_energy = global_dft_energy;
+
+  MPI_Type_free(&dft_type);
+}

--- a/src/TotalEnergy/DFTEnergy.hpp
+++ b/src/TotalEnergy/DFTEnergy.hpp
@@ -1,0 +1,71 @@
+//
+// Created by F.Moitzi on 05.07.2022.
+//
+
+#ifndef LSMS_DFTENERGY_HPP
+#define LSMS_DFTENERGY_HPP
+
+#include "LSMSCommunication.hpp"
+#include "Real.hpp"
+
+namespace lsms {
+
+class DFTEnergy {
+ public:
+  DFTEnergy() = default;
+
+  Real zero_point = 0.0;
+
+  Real core_eigen = 0.0;
+
+  Real semicore_eigen = 0.0;
+
+  Real one_ele = 0.0;
+
+  Real ks = 0.0;
+
+  Real kinetic = 0.0;
+
+  Real hartree = 0.0;
+
+  Real core_hartree = 0.0;
+
+  Real coloumb = 0.0;
+
+  Real xc = 0.0;
+
+  Real lsf = 0.0;
+
+  Real total = 0.0;
+
+  Real madelung = 0.0;
+
+  Real shift = 0.0;
+
+  DFTEnergy &operator+=(const DFTEnergy &rhs) {
+    this->zero_point += rhs.zero_point;
+    this->core_eigen += rhs.core_eigen;
+    this->semicore_eigen += rhs.semicore_eigen;
+    this->one_ele += rhs.one_ele;
+    this->ks += rhs.ks;
+    this->kinetic += rhs.kinetic;
+    this->hartree += rhs.hartree;
+    this->core_hartree += rhs.core_hartree;
+    this->coloumb += rhs.coloumb;
+    this->xc += rhs.xc;
+    this->lsf += rhs.lsf;
+    this->total += rhs.total;
+    this->madelung += rhs.madelung;
+    this->shift += rhs.shift;
+
+    return *this;
+  }
+};
+
+void globalSum(LSMSCommunication &comm, DFTEnergy &dft_energy);
+
+void print_dft_energy(const DFTEnergy &energy);
+
+}  // namespace lsms
+
+#endif  // LSMS_DFTENERGY_HPP

--- a/src/TotalEnergy/calculateTotalEnergy.hpp
+++ b/src/TotalEnergy/calculateTotalEnergy.hpp
@@ -1,19 +1,27 @@
 #ifndef CALCULATE_TOTAL_ENERGY_HPP
 #define CALCULATE_TOTAL_ENERGY_HPP
 
-#include "Main/SystemParameters.hpp"
 #include "Communication/LSMSCommunication.hpp"
+#include "Main/SystemParameters.hpp"
 #include "Real.hpp"
+#include "TotalEnergy/DFTEnergy.hpp"
 
-void calculateTotalEnergy(LSMSCommunication &comm, LSMSSystemParameters &lsms, LocalTypeInfo &local, CrystalParameters &crystal); 
-
-extern "C"
-{
-  void janake_(Real *vrold, Real *vrnew, Real *rhotot, Real *rhonew, Real *corden,
-               Real *rr, Real *rins, Real *rmt, int *jmt, int *jws, int *komp, Real *atcon,
-               Real *ztotss_dum, Real *atvol, Real *vx, Real *enxc, Real *evalsum, 
-               Real *ecorv, Real *esemv, Real *etot, Real *press, Real *rspin,
-               int *iprpts, int *iprint, char *istop, int istopl_len);
+extern "C" {
+void janake_(Real *vrold, Real *vrnew, Real *rhotot, Real *rhonew, Real *corden,
+             Real *rr, Real *rins, Real *rmt, int *jmt, int *jws, int *komp,
+             Real *atcon, Real *ztotss_dum, Real *atvol, Real *vx, Real *enxc,
+             Real *evalsum, Real *ecorv, Real *esemv, Real *etot, Real *press,
+             Real *rspin, int *iprpts, int *iprint, char *istop,
+             int istopl_len);
 }
+
+void calculateTotalEnergy(LSMSCommunication &comm, LSMSSystemParameters &lsms,
+                          LocalTypeInfo &local, CrystalParameters &crystal);
+
+void calculateTotalEnergy(LSMSCommunication &comm, LSMSSystemParameters &lsms,
+                          LocalTypeInfo &local, CrystalParameters &crystal,
+                          lsms::DFTEnergy &dft_energy);
+
+
 
 #endif

--- a/src/TotalEnergy/localTotalEnergy.cpp
+++ b/src/TotalEnergy/localTotalEnergy.cpp
@@ -4,12 +4,8 @@
 #include <cmath>
 
 #include "Misc/integrator.hpp"
-#include "PhysicalConstants.hpp"
 #include "Misc/poisson.hpp"
-
-extern "C" {
-void zeropt_(Real *ezpt, Real *tpzpt, Real *atvol, Real *ztotss);
-}
+#include "PhysicalConstants.hpp"
 
 /**
  * Calculates the total energy `energy` for each site
@@ -19,9 +15,8 @@ void zeropt_(Real *ezpt, Real *tpzpt, Real *atvol, Real *ztotss);
  * @param energy total energy
  * @param pressure total pressure
  */
-void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
-                      Real &energy, Real &pressure) {
-
+void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom, Real &energy,
+                      Real &pressure) {
   Real eigenvalueSum = 0.0;
   Real kineticEnergy = 0.0;
   Real coulombEnergy = 0.0;
@@ -29,6 +24,7 @@ void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
   Real ezpt = 0.0;
   Real tpzpt = 0.0;
   Real lsf_energy = 0.0;
+  Real ks = 0.0;
   std::vector<Real> integral(atom.r_mesh.size());
   std::vector<Real> integrand(atom.r_mesh.size());
 
@@ -62,7 +58,7 @@ void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
    * Kinetic energy contributions
    */
   if (lsms.n_spin_pola == 1) {
-    eigenvalueSum = atom.evalsum[0] + atom.esemv[0];
+    eigenvalueSum = atom.ecorv[0] + atom.esemv[0];
 
     kineticEnergy = atom.ecorv[0] + atom.esemv[0];  // (1)
     kineticEnergy += atom.evalsum[0];               // (2)
@@ -73,7 +69,7 @@ void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
 
   } else {  // spin polarized
     eigenvalueSum =
-        atom.evalsum[0] + atom.evalsum[1] + atom.esemv[0] + atom.esemv[1];
+        atom.ecorv[0] + atom.ecorv[1] + atom.esemv[0] + atom.esemv[1];
 
     kineticEnergy =
         atom.ecorv[0] + atom.ecorv[1] + atom.esemv[0] + atom.esemv[1];  // (1)
@@ -86,11 +82,12 @@ void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
     }
   }
 
-
-  kineticEnergy -= lsms::radialIntegral(integrand, atom.r_mesh, rSphere);
+  ks = lsms::radialIntegral(integrand, atom.r_mesh, rSphere);
+  kineticEnergy -= ks;
 
   if (lsms.global.iprint >= 0) {
     printf("evssum                      = %35.25lf Ry\n", eigenvalueSum);
+    printf("ks                          = %35.25lf Ry\n", ks);
     printf("kinetic Energy              = %35.25lf Ry\n", kineticEnergy);
   }
 
@@ -159,14 +156,12 @@ void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
   }
   Real ezrho = -lsms::radialIntegral(integrand, atom.r_mesh, rSphere);
 
-
-//  FILE *fp;
-//  fp = fopen("example.txt","w");
-//  for(int ir = 0; ir < atom.r_mesh.size(); ir++) {
-//    std::fprintf(fp, "%.30e %.30e\n", integrand[ir], atom.r_mesh[ir]);
-//  }
-//  std::fclose(fp);
-
+  //  FILE *fp;
+  //  fp = fopen("example.txt","w");
+  //  for(int ir = 0; ir < atom.r_mesh.size(); ir++) {
+  //    std::fprintf(fp, "%.30e %.30e\n", integrand[ir], atom.r_mesh[ir]);
+  //  }
+  //  std::fclose(fp);
 
   if (lsms.global.iprint >= 0) {
     printf("ezrho                       = %35.25lf Ry\n", ezrho);
@@ -181,21 +176,19 @@ void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
    */
   if (lsms.n_spin_pola == 1) {
     for (int i = 0; i < atom.r_mesh.size(); i++) {
-      integrand[i] =
-          (atom.rhoNew(i, 0) * atom.exchangeCorrelationEnergy(i, 0));
+      integrand[i] = (atom.rhoNew(i, 0) * atom.exchangeCorrelationEnergy(i, 0));
     }
   } else {  // spin polarized
     for (int i = 0; i < atom.r_mesh.size(); i++) {
-      integrand[i] =
-          (atom.rhoNew(i, 0) * atom.exchangeCorrelationEnergy(i, 0) +
-           atom.rhoNew(i, 1) * atom.exchangeCorrelationEnergy(i, 1));
+      integrand[i] = (atom.rhoNew(i, 0) * atom.exchangeCorrelationEnergy(i, 0) +
+                      atom.rhoNew(i, 1) * atom.exchangeCorrelationEnergy(i, 1));
     }
   }
   xcEnergy = lsms::radialIntegral(integrand, atom.r_mesh, rSphere);
 
   if (lsms.global.iprint >= 0) {
     printf("Exchange-Correlation Energy = %35.25lf Ry\n", xcEnergy);
-    printf("ezpt                        = %35.25lf Ry\n\n", ezpt);
+    printf("ezpt                        = %35.25lf Ry\n", ezpt);
   }
 
   /**
@@ -208,8 +201,170 @@ void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
   }
 
   if (lsms.global.iprint >= 0) {
-    printf("LSF energy                  = %35.25lf Ry\n\n", lsf_energy);
+    printf("LSF energy                  = %35.25lf Ry\n", lsf_energy);
   }
 
   energy += kineticEnergy + coulombEnergy + xcEnergy + ezpt + lsf_energy;
+}
+
+/**
+ * Calculates the total energy `energy` for each site
+ *
+ * @param lsms system parameters
+ * @param atom atom object
+ * @param energy total energy class
+ */
+void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
+                      lsms::DFTEnergy &dft_energy) {
+  Real xcEnergy = 0.0;
+  Real ezpt = 0.0;
+  Real tpzpt = 0.0;
+  Real lsf_energy = 0.0;
+  std::vector<Real> integral(atom.r_mesh.size());
+  std::vector<Real> integrand(atom.r_mesh.size());
+
+  int spin_channels;
+
+  Real rSphere;
+  switch (lsms.mtasa) {
+    case 1:
+      rSphere = atom.rws;
+      break;
+    case 2:
+      rSphere = atom.rws;
+      break;
+    default:
+      rSphere = atom.rInscribed;
+  }
+
+  /**
+   * Vibrational Zero-Point Energies (ZPE)
+   */
+  zeropt_(&ezpt, &tpzpt, &atom.omegaWS, &atom.ztotss);
+  dft_energy.zero_point = ezpt;
+
+  /**
+   * Kinetic energy T:
+   * T = \sum_{Core} e_i                            -- (1)
+   *   + \int^{E_F} e n(e) de                       -- (2)
+   *   - \int \rho(r) (v_{Coulomb} + v_{xc}) d^3r   -- (3)
+   *   + \int m(r) (B_{xc} + B_{external}) d^3      -- (4)
+   */
+  if (lsms.n_spin_pola == 1) {
+    spin_channels = 1;
+  } else {  // spin polarized
+    spin_channels = 2;
+  }
+
+  for (int spin = 0; spin < spin_channels; spin++) {
+    for (int i = 0; i < atom.r_mesh.size(); i++) {
+      integrand[i] +=
+          (atom.rhoNew(i, spin) * atom.vr(i, spin)) / (atom.r_mesh[i]);
+    }
+
+    dft_energy.core_eigen += atom.ecorv[spin];
+    dft_energy.semicore_eigen += atom.esemv[spin];
+    dft_energy.one_ele += atom.evalsum[spin];
+  }
+
+  dft_energy.ks = lsms::radialIntegral(integrand, atom.r_mesh, rSphere);
+
+  dft_energy.kinetic = dft_energy.core_eigen + dft_energy.semicore_eigen +
+                       dft_energy.one_ele - dft_energy.ks;
+
+  /**
+   * calculate Coulomb Energy E_C:
+   * E_C = \int \rho(r) v_{Coulomb} d^3r          -- (5)
+   *     + E_{Madelung}                           -- (6) // external to this
+   *     routine
+   * break the Coulomb integral in two parts:
+   *  \int \rho(r) v_{Coulomb} d^3r
+   *      = \int \rho(r) \int^r rho(r')/r' dr' dr -- (5a)
+   *      + \int rho(r) Z/r dr                    -- (5b)
+   *
+   */
+
+  std::vector<double> vhartreederiv(atom.r_mesh.size(), 0.0);
+  std::vector<double> vhartree(atom.r_mesh.size(), 0.0);
+  std::vector<double> density(atom.r_mesh.size(), 0.0);
+
+  if (lsms.n_spin_pola == 1) {
+    for (auto i = 0; i < atom.r_mesh.size(); i++) {
+      density[i] = atom.rhoNew(i, 0);
+    }
+  } else {
+    for (auto i = 0; i < atom.r_mesh.size(); i++) {
+      density[i] = (atom.rhoNew(i, 0) + atom.rhoNew(i, 1));
+    }
+  }
+  std::vector<double> radial_mesh_deriv(atom.r_mesh.size(), 0.0);
+
+  for (auto i = 0; i < atom.r_mesh.size(); i++) {
+    radial_mesh_deriv[i] = atom.r_mesh[i] * atom.h;
+  }
+
+  lsms::radial_poisson(vhartree, vhartreederiv, atom.r_mesh, radial_mesh_deriv,
+                       density, atom.jmt);
+
+  if (lsms.n_spin_pola == 1) {
+    for (auto i = 0; i < atom.r_mesh.size(); i++) {
+      integral[i] = vhartree[i] * atom.rhoNew(i, 0);
+    }
+  } else {
+    for (auto i = 0; i < atom.r_mesh.size(); i++) {
+      integral[i] = vhartree[i] * (atom.rhoNew(i, 0) + atom.rhoNew(i, 1));
+    }
+  }
+
+  double erho = lsms::radialIntegral(integral, atom.r_mesh, rSphere);
+  dft_energy.hartree = erho;
+
+  /**
+   * Calculation of the Coulomb contribution (5b)
+   */
+  if (lsms.n_spin_pola == 1) {
+    for (int i = 0; i < atom.r_mesh.size(); i++) {
+      integrand[i] = 2.0 * (atom.rhoNew(i, 0)) * atom.ztotss / (atom.r_mesh[i]);
+    }
+  } else {  // spin polarized
+    for (int i = 0; i < atom.r_mesh.size(); i++) {
+      integrand[i] = 2.0 * (atom.rhoNew(i, 0) + atom.rhoNew(i, 1)) *
+                     atom.ztotss / (atom.r_mesh[i]);
+    }
+  }
+
+  Real ezrho = -lsms::radialIntegral(integrand, atom.r_mesh, rSphere);
+  dft_energy.core_hartree = ezrho;
+
+  dft_energy.coloumb = dft_energy.core_hartree + dft_energy.hartree;
+
+  /**
+   * Exchange-Correlation energy                  -- (7)
+   */
+  if (lsms.n_spin_pola == 1) {
+    for (int i = 0; i < atom.r_mesh.size(); i++) {
+      integrand[i] = (atom.rhoNew(i, 0) * atom.exchangeCorrelationEnergy(i, 0));
+    }
+  } else {  // spin polarized
+    for (int i = 0; i < atom.r_mesh.size(); i++) {
+      integrand[i] = (atom.rhoNew(i, 0) * atom.exchangeCorrelationEnergy(i, 0) +
+                      atom.rhoNew(i, 1) * atom.exchangeCorrelationEnergy(i, 1));
+    }
+  }
+
+  xcEnergy = lsms::radialIntegral(integrand, atom.r_mesh, rSphere);
+  dft_energy.xc = xcEnergy;
+
+  /**
+   * Longitudinal spin fluctuations
+   */
+  if (lsms.n_spin_pola == 2) {
+    auto mag_mom = atom.mvalws;
+    lsf_energy += -convertKtoRydberg * lsms.temperature *
+                  atom.lsf_functional.entropy(mag_mom);
+  }
+  dft_energy.lsf = lsf_energy;
+
+  dft_energy.total = dft_energy.kinetic + dft_energy.coloumb + dft_energy.xc +
+                     dft_energy.zero_point + dft_energy.lsf;
 }

--- a/src/TotalEnergy/localTotalEnergy.hpp
+++ b/src/TotalEnergy/localTotalEnergy.hpp
@@ -3,15 +3,16 @@
 #define MUST_LOCALTOTALENERGY_HPP
 
 #include "Main/SystemParameters.hpp"
+#include "TotalEnergy/DFTEnergy.hpp"
 
-extern "C"
-{
+extern "C" {
 void zeropt_(Real *ezpt, Real *tpzpt, Real *atvol, Real *ztotss);
 }
 
-void
-localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom, Real &energy, Real &pressure);
+void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom, Real &energy,
+                      Real &pressure);
 
+void localTotalEnergy(LSMSSystemParameters &lsms, AtomData &atom,
+                      lsms::DFTEnergy &dft_energy);
 
-
-#endif //MUST_LOCALTOTALENERGY_HPP
+#endif  // MUST_LOCALTOTALENERGY_HPP


### PR DESCRIPTION
Add the moment there is not global output for the components of the DFT energies. Only the total and band energy is plotted. Now we also display all contributions after the last step.

Here is an example:

```
SCF iteration 1:
Band Energy = 8.959928 Ry           Fermi Energy = 0.690165 Ry
Total Energy = -5845.849215 Ry
RMS = 5.52917e-06
===================
Core         =  -3291.5434080425 Ry
Semicore     =    -72.1542420524 Ry
One electron =      8.9599275552 Ry
Kohn-Sham    =  -9290.0246885795 Ry
Kinetic      =   5935.2869660397 Ry
Hartree      =   2489.6782642725 Ry
Core Hartree = -14032.9369021218 Ry
Coloumb      = -11543.2586378493 Ry
XC           =   -236.1970958257 Ry
ZPE          =      0.0059083640 Ry
LSF          =      0.0000000000 Ry
Madelung     =     -1.0491521290 Ry
MT Zero      =     -0.6364789925 Ry
Total energy =  -5845.8484903928 Ry
===================
Writing new potentials.
Writing restart file.
Band Energy = 8.959927555180634 Ry
Fermi Energy = 0.690164951275447 Ry
Total Energy = -5845.848490392773783 Ry
```