### PR TITLE
Use CMake for building libxc library

### DIFF
--- a/external/libxc-6.1.0/cmake/psi4OptionsTools.cmake
+++ b/external/libxc-6.1.0/cmake/psi4OptionsTools.cmake
@@ -21,7 +21,10 @@ endmacro()
 #
 macro(option_with_print variable msge default)
    print_option(${variable} ${default})
-   option(${variable} ${msge} ${default})
+   # don't redefine the variable if it is already defined
+   if(NOT DEFINED ${variable})
+       option(${variable} ${msge} ${default})
+   endif()
 endmacro(option_with_print)
 
 #Wraps an option with a default other than ON/OFF and prints it


### PR DESCRIPTION
In cmake/libxc.cmake, replace Makefile with the CMake method provided by the library. Currently, all libraries use CMake to build targets except for libxc. This commit allows libxc to be built using CMake.