### PR TITLE
compare floats in buildKKRMatrix_CPU using tolerance

### DIFF
--- a/src/MultipleScattering/buildKKRMatrix.hpp
+++ b/src/MultipleScattering/buildKKRMatrix.hpp
@@ -27,7 +27,7 @@
 void buildKKRMatrixCPU(LSMSSystemParameters &lsms, LocalTypeInfo &local,
                        AtomData &atom, int ispin, int iie, Complex energy,
                        Complex prel, Matrix<Complex> &m);
-#define MST_BUILD_KKR_MATRIX_CUDA 0x3000
+#define MST_BUILD_KKR_MATRIX_ACCELERATOR 0x3000
 #ifdef ACCELERATOR_CUDA_C
 void buildKKRMatrixCuda(LSMSSystemParameters &lsms, LocalTypeInfo &local,
                         AtomData &atom, DeviceStorage &d, DeviceAtom &devAtom,


### PR DESCRIPTION
In buildKKRMatrix_CPU, adding tolerance-based comparison for float values. This pertains to all comparisons performed when `COMPARE_ORIGINAL` is set. Also changing the format of printing floats from `%g` to `%.15f` for a more clear representation of the floats when the comparisons fail.

Also fixed a couple minor printing bugs.

Question - Use of `bgijSmall` here seems out of place since `bgijSmall` is not computed anywhere. Should this be replaced with `bgij`? https://github.com/mstsuite/lsms/blob/master/src/MultipleScattering/buildKKRMatrix_CPU.cpp#L380